### PR TITLE
Feat/add tests and groundwork for table expressions

### DIFF
--- a/internal/data/companies.go
+++ b/internal/data/companies.go
@@ -60,10 +60,10 @@ func (c CompanyModel) GetAll() ([]*Company, error) {
 }
 
 func (c CompanyModel) Insert(company *Company) error {
-	values := querybuilder.ClauseMap{
-		"name":        company.Name,
-		"icon":        company.Icon,
-		"description": company.Description,
+	values := querybuilder.Clauses{
+		querybuilder.Clause{ColumnName: "name", Value: company.Name},
+		querybuilder.Clause{ColumnName: "icon", Value: company.Icon},
+		querybuilder.Clause{ColumnName: "description", Value: company.Description},
 	}
 
 	row, err := c.Query.SetBaseTable("companies").Insert(values).Returning("id").QueryRow()
@@ -94,10 +94,10 @@ func (c CompanyModel) Get(companyId int64) (*Company, error) {
 }
 
 func (c CompanyModel) Update(company *Company) error {
-	values := querybuilder.ClauseMap{
-		"name":        company.Name,
-		"icon":        company.Icon,
-		"description": company.Description,
+	values := querybuilder.Clauses{
+		querybuilder.Clause{ColumnName: "name", Value: company.Name},
+		querybuilder.Clause{ColumnName: "icon", Value: company.Icon},
+		querybuilder.Clause{ColumnName: "description", Value: company.Description},
 	}
 
 	results, err := c.Query.SetBaseTable("companies").Update(values).WhereEqual("id", company.ID).Exec()

--- a/pkg/querybuilder/delete.go
+++ b/pkg/querybuilder/delete.go
@@ -24,7 +24,7 @@ func (q DeleteQueryBuilder) buildQuery() (*string, error) {
 	}
 
 	query := fmt.Sprintf("DELETE FROM %s", q.table)
-	query += q.queryBuilder.buildConditionalStatement(q.conditions, 0)
+	query += q.queryBuilder.buildConditionalStatement(q.conditions)
 
 	return &query, nil
 }

--- a/pkg/querybuilder/delete.go
+++ b/pkg/querybuilder/delete.go
@@ -9,7 +9,7 @@ import (
 type DeleteQueryBuilder struct {
 	queryBuilder QueryBuilder
 	table        string
-	conditions   ClauseMap
+	conditions   Clauses
 }
 
 func (q DeleteQueryBuilder) buildQuery() (*string, error) {

--- a/pkg/querybuilder/delete_test.go
+++ b/pkg/querybuilder/delete_test.go
@@ -22,7 +22,7 @@ func TestDeleteQueryBuilder_WhereEqual(t *testing.T) {
 
 	DeleteQB := qb.SetBaseTable("users").Delete().WhereEqual("id", 1)
 
-	expectedConditions := ClauseMap{"id:=": 1}
+	expectedConditions := append(Clauses{}, Clause{ColumnName: "id:=", Value: 1})
 	if !reflect.DeepEqual(DeleteQB.conditions, expectedConditions) {
 		t.Errorf("Expected conditions to be %v, got %v", expectedConditions, DeleteQB.conditions)
 	}

--- a/pkg/querybuilder/delete_test.go
+++ b/pkg/querybuilder/delete_test.go
@@ -1,0 +1,51 @@
+package querybuilder
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDeleteQueryBuilder_Fails_Without_Where(t *testing.T) {
+	qb := QueryBuilder{}
+
+	DeleteQB := qb.Delete()
+
+	_, err := DeleteQB.buildQuery()
+
+	if err == nil {
+		t.Fatalf("Expected error for missing conditions, got nil")
+	}
+}
+
+func TestDeleteQueryBuilder_WhereEqual(t *testing.T) {
+	qb := QueryBuilder{}
+
+	DeleteQB := qb.SetBaseTable("users").Delete().WhereEqual("id", 1)
+
+	expectedConditions := ClauseMap{"id:=": 1}
+	if !reflect.DeepEqual(DeleteQB.conditions, expectedConditions) {
+		t.Errorf("Expected conditions to be %v, got %v", expectedConditions, DeleteQB.conditions)
+	}
+
+	query, err := DeleteQB.buildQuery()
+
+	expectedQuery := "DELETE FROM users WHERE id = $1"
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if *query != expectedQuery {
+		t.Errorf("Expected query to be '%s', got '%s'", expectedQuery, *query)
+	}
+}
+
+func TestDeleteQueryBuilder_NoTable(t *testing.T) {
+	qb := QueryBuilder{}
+
+	DeleteQB := qb.Delete().WhereEqual("id", 1)
+
+	_, err := DeleteQB.buildQuery()
+
+	if err == nil {
+		t.Error("Expected error for missing table, got nil")
+	}
+}

--- a/pkg/querybuilder/insert.go
+++ b/pkg/querybuilder/insert.go
@@ -9,24 +9,19 @@ import (
 type InsertQueryBuilder struct {
 	queryBuilder QueryBuilder
 	table        string
-	values       ClauseMap
+	values       Clauses
 	fields       []string
 }
 
 func (q InsertQueryBuilder) buildColumnNameStatement() string {
-	keys := make([]string, 0, len(q.values))
-	for k := range q.values {
-		keys = append(keys, k)
-	}
-
 	stmt := ""
 
-	if len(keys) != 0 {
-		for i, column := range keys {
+	if len(q.values) != 0 {
+		for i, column := range q.values {
 			if i > 0 {
 				stmt += ", "
 			}
-			stmt += fmt.Sprintf("%s", column)
+			stmt += fmt.Sprintf("%s", column.ColumnName)
 		}
 	}
 

--- a/pkg/querybuilder/insert.go
+++ b/pkg/querybuilder/insert.go
@@ -13,26 +13,6 @@ type InsertQueryBuilder struct {
 	fields       []string
 }
 
-func (q InsertQueryBuilder) buildValuesStatement() string {
-	keys := make([]string, 0, len(q.values))
-	for k := range q.values {
-		keys = append(keys, k)
-	}
-
-	stmt := ""
-
-	if len(keys) != 0 {
-		for i := range keys {
-			if i > 0 {
-				stmt += ", "
-			}
-			stmt += fmt.Sprintf("$%d", i+1)
-		}
-	}
-
-	return stmt
-}
-
 func (q InsertQueryBuilder) buildColumnNameStatement() string {
 	keys := make([]string, 0, len(q.values))
 	for k := range q.values {
@@ -53,21 +33,6 @@ func (q InsertQueryBuilder) buildColumnNameStatement() string {
 	return stmt
 }
 
-func (q InsertQueryBuilder) buildReturnedColumns() string {
-	stmt := ""
-
-	if len(q.fields) != 0 {
-		for i, field := range q.fields {
-			if i > 0 {
-				stmt += ", "
-			}
-			stmt += fmt.Sprintf("%s", field)
-		}
-	}
-
-	return stmt
-}
-
 func (q InsertQueryBuilder) buildQuery() (*string, error) {
 	if len(q.values) == 0 {
 		err := errors.New("Incorrectly formatted query. Ensure fields are set")
@@ -79,10 +44,10 @@ func (q InsertQueryBuilder) buildQuery() (*string, error) {
 	}
 
 	columnNames := q.buildColumnNameStatement()
-	columnValues := q.buildValuesStatement()
+	columnValues := q.queryBuilder.buildValuesStatement(q.values)
 	query := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", q.table, columnNames, columnValues)
 	if len(q.fields) > 0 {
-		returnedColumns := q.buildReturnedColumns()
+		returnedColumns := q.queryBuilder.buildReturnedColumns(q.fields)
 		query += fmt.Sprintf(" RETURNING %s", returnedColumns)
 	}
 

--- a/pkg/querybuilder/insert_test.go
+++ b/pkg/querybuilder/insert_test.go
@@ -1,0 +1,77 @@
+package querybuilder
+
+import (
+	"testing"
+)
+
+func TestInsertQueryBuilder_buildColumnNameStatement(t *testing.T) {
+	qb := QueryBuilder{}
+	values := ClauseMap{
+		"name": "John",
+		"age":  30,
+	}
+
+	insertQB := InsertQueryBuilder{queryBuilder: qb, values: values}
+
+	columnStmt := insertQB.buildColumnNameStatement()
+
+	expectedStmt := "name, age"
+	if columnStmt != expectedStmt {
+		t.Errorf("Expected column statement to be '%s', got '%s'", expectedStmt, columnStmt)
+	}
+}
+
+func TestInsertQueryBuilder_buildQuery(t *testing.T) {
+	qb := QueryBuilder{}
+	values := ClauseMap{
+		"name": "John",
+		"age":  30,
+	}
+
+	insertQB := qb.SetBaseTable("users").Insert(values)
+
+	query, err := insertQB.buildQuery()
+
+	expectedQuery := "INSERT INTO users (name, age) VALUES ($1, $2)"
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if *query != expectedQuery {
+		t.Errorf("Expected query to be '%s', got '%s'", expectedQuery, *query)
+	}
+}
+
+func TestInsertQueryBuilder_NoTable(t *testing.T) {
+	qb := QueryBuilder{}
+	values := ClauseMap{
+		"name": "John",
+	}
+
+	insertQB := qb.Insert(values)
+
+	_, err := insertQB.buildQuery()
+
+	if err == nil {
+		t.Error("Expected error for missing table, got nil")
+	}
+}
+
+func TestInsertQueryBuilder_Returning(t *testing.T) {
+	qb := QueryBuilder{}
+	values := ClauseMap{
+		"name": "John",
+		"age":  30,
+	}
+
+	insertQB := qb.SetBaseTable("users").Insert(values).Returning("id", "created_at")
+
+	query, err := insertQB.buildQuery()
+
+	expectedQuery := "INSERT INTO users (name, age) VALUES ($1, $2) RETURNING id, created_at"
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if *query != expectedQuery {
+		t.Errorf("Expected query to be '%s', got '%s'", expectedQuery, *query)
+	}
+}

--- a/pkg/querybuilder/insert_test.go
+++ b/pkg/querybuilder/insert_test.go
@@ -6,10 +6,7 @@ import (
 
 func TestInsertQueryBuilder_buildColumnNameStatement(t *testing.T) {
 	qb := QueryBuilder{}
-	values := ClauseMap{
-		"name": "John",
-		"age":  30,
-	}
+	values := append(Clauses{}, Clause{ColumnName: "name", Value: "John"}, Clause{ColumnName: "age", Value: 30})
 
 	insertQB := InsertQueryBuilder{queryBuilder: qb, values: values}
 
@@ -23,10 +20,7 @@ func TestInsertQueryBuilder_buildColumnNameStatement(t *testing.T) {
 
 func TestInsertQueryBuilder_buildQuery(t *testing.T) {
 	qb := QueryBuilder{}
-	values := ClauseMap{
-		"name": "John",
-		"age":  30,
-	}
+	values := append(Clauses{}, Clause{ColumnName: "name", Value: "John"}, Clause{ColumnName: "age", Value: 30})
 
 	insertQB := qb.SetBaseTable("users").Insert(values)
 
@@ -43,9 +37,7 @@ func TestInsertQueryBuilder_buildQuery(t *testing.T) {
 
 func TestInsertQueryBuilder_NoTable(t *testing.T) {
 	qb := QueryBuilder{}
-	values := ClauseMap{
-		"name": "John",
-	}
+	values := append(Clauses{}, Clause{ColumnName: "name", Value: "John"})
 
 	insertQB := qb.Insert(values)
 
@@ -58,10 +50,7 @@ func TestInsertQueryBuilder_NoTable(t *testing.T) {
 
 func TestInsertQueryBuilder_Returning(t *testing.T) {
 	qb := QueryBuilder{}
-	values := ClauseMap{
-		"name": "John",
-		"age":  30,
-	}
+	values := append(Clauses{}, Clause{ColumnName: "name", Value: "John"}, Clause{ColumnName: "age", Value: 30})
 
 	insertQB := qb.SetBaseTable("users").Insert(values).Returning("id", "created_at")
 

--- a/pkg/querybuilder/querybuilder.go
+++ b/pkg/querybuilder/querybuilder.go
@@ -9,9 +9,15 @@ import (
 type ClauseMap map[string]interface{}
 
 type QueryBuilder struct {
-	DB     *sql.DB
-	fields []string
-	table  string
+	DB                     *sql.DB
+	table                  string
+	preparedVariableOffset int
+	commonTableExpressions []CommonQueryBuilder
+}
+
+type CommonQueryBuilder interface {
+	buildQuery() (*string, error)
+	buildPreparedStatementValues() []interface{}
 }
 
 func (q *QueryBuilder) SetBaseTable(table string) *QueryBuilder {
@@ -35,6 +41,15 @@ func (q QueryBuilder) Delete() DeleteQueryBuilder {
 	return DeleteQueryBuilder{queryBuilder: q, table: q.table}
 }
 
+func (q QueryBuilder) With(query CommonQueryBuilder, name string) QueryBuilder {
+	if q.commonTableExpressions == nil {
+		q.commonTableExpressions = make([]CommonQueryBuilder, 0)
+	}
+
+	q.commonTableExpressions = append(q.commonTableExpressions, query)
+	return q
+}
+
 func (q *QueryBuilder) addCondition(column string, value interface{}, comparer string, conditions *ClauseMap) {
 	if *conditions == nil {
 		*conditions = (make(map[string]interface{}))
@@ -43,7 +58,53 @@ func (q *QueryBuilder) addCondition(column string, value interface{}, comparer s
 	(*conditions)[key] = value
 }
 
-func (q QueryBuilder) buildConditionalStatement(conditions ClauseMap, preparedVariableOffset int) string {
+func (q *QueryBuilder) buildColumnUpdateStatement(values ClauseMap) string {
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+
+	stmt := ""
+	i, column := 0, ""
+
+	if len(keys) != 0 {
+		stmt += " SET"
+
+		for i, column = range keys {
+			if i > 0 {
+				stmt += ","
+			}
+			stmt += fmt.Sprintf(" %s = $%d", column, i+q.preparedVariableOffset+1)
+		}
+	}
+	q.preparedVariableOffset = q.preparedVariableOffset + i + 1
+	// return fmt.Sprintf("number: %d", q.preparedVariableOffset)
+	return stmt
+}
+
+func (q *QueryBuilder) buildValuesStatement(values ClauseMap) string {
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+
+	stmt := ""
+	i := 0
+
+	if len(keys) != 0 {
+		for i = range keys {
+			if i > 0 {
+				stmt += ", "
+			}
+			stmt += fmt.Sprintf("$%d", i+q.preparedVariableOffset+1)
+		}
+	}
+
+	q.preparedVariableOffset += i + 1
+	return stmt
+}
+
+func (q *QueryBuilder) buildConditionalStatement(conditions ClauseMap) string {
 	keys := make([]string, 0, len(conditions))
 	for k := range conditions {
 		keys = append(keys, k)
@@ -63,16 +124,18 @@ func (q QueryBuilder) buildConditionalStatement(conditions ClauseMap, preparedVa
 			if comparer == "IS NULL" || comparer == "IS NOT NULL" {
 				stmt += fmt.Sprintf(" %s %s", column, comparer)
 			} else {
-				stmt += fmt.Sprintf(" %s %s $%d", column, comparer, preparedStatementCount+preparedVariableOffset+1)
+				stmt += fmt.Sprintf(" %s %s $%d", column, comparer, preparedStatementCount+q.preparedVariableOffset+1)
 				preparedStatementCount++
 			}
 		}
+
+		q.preparedVariableOffset += preparedStatementCount
 	}
 
 	return stmt
 }
 
-func (q QueryBuilder) buildParameters(parameters ClauseMap) []interface{} {
+func (q *QueryBuilder) buildParameters(parameters ClauseMap) []interface{} {
 	values := make([]interface{}, 0, len(parameters))
 	for _, v := range parameters {
 		if v != nil {
@@ -80,4 +143,19 @@ func (q QueryBuilder) buildParameters(parameters ClauseMap) []interface{} {
 		}
 	}
 	return values
+}
+
+func (q *QueryBuilder) buildReturnedColumns(fields []string) string {
+	stmt := ""
+
+	if len(fields) != 0 {
+		for i, field := range fields {
+			if i > 0 {
+				stmt += ", "
+			}
+			stmt += fmt.Sprintf("%s", field)
+		}
+	}
+
+	return stmt
 }

--- a/pkg/querybuilder/querybuilder_test.go
+++ b/pkg/querybuilder/querybuilder_test.go
@@ -1,0 +1,108 @@
+package querybuilder
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSetBaseTable(t *testing.T) {
+	qb := QueryBuilder{}
+	qb.SetBaseTable("users")
+
+	if qb.table != "users" {
+		t.Errorf("Expected table to be 'users', got %s", qb.table)
+	}
+}
+
+func TestInsertQueryBuilder(t *testing.T) {
+	qb := QueryBuilder{}
+	insertQB := qb.SetBaseTable("users").Insert(ClauseMap{"name": "John Doe", "age": 30}).Returning("id", "created_at")
+
+	if insertQB.table != "users" {
+		t.Errorf("Expected table to be 'users', got %s", insertQB.table)
+	}
+
+	expectedValues := ClauseMap{"name": "John Doe", "age": 30}
+	if !reflect.DeepEqual(insertQB.values, expectedValues) {
+		t.Errorf("Expected values to be %v, got %v", expectedValues, insertQB.values)
+	}
+
+	query, err := insertQB.buildQuery()
+	if err != nil {
+		t.Errorf("Unexpected error when building insert query, got %s", err)
+		return
+	}
+
+	if *query != "INSERT INTO users (name, age) VALUES ($1, $2) RETURNING id, created_at" {
+		t.Errorf("Expected query was not generated got: %s", *query)
+	}
+}
+
+func TestDeleteQueryBuilder(t *testing.T) {
+	qb := QueryBuilder{}
+	deleteQB := qb.SetBaseTable("users").Delete()
+
+	if deleteQB.table != "users" {
+		t.Errorf("Expected table to be 'users', got %s", deleteQB.table)
+	}
+}
+
+func TestAddCondition(t *testing.T) {
+	qb := QueryBuilder{}
+	conditions := make(ClauseMap)
+	qb.addCondition("age", 30, "=", &conditions)
+
+	expectedConditions := ClauseMap{"age:=": 30}
+	if !reflect.DeepEqual(conditions, expectedConditions) {
+		t.Errorf("Expected conditions to be %v, got %v", expectedConditions, conditions)
+	}
+}
+
+func TestBuildValuesStatement(t *testing.T) {
+	qb := QueryBuilder{}
+	qb.preparedVariableOffset = 0
+	values := ClauseMap{"name": "John Doe", "age": 30}
+
+	stmt := qb.buildValuesStatement(values)
+
+	expectedStmt := "$1, $2"
+	if stmt != expectedStmt {
+		t.Errorf("Expected statement to be '%s', got '%s'", expectedStmt, stmt)
+	}
+}
+
+func TestBuildConditionalStatement(t *testing.T) {
+	qb := QueryBuilder{}
+	conditions := ClauseMap{"age:>": 30, "name:=": "John Doe"}
+
+	stmt := qb.buildConditionalStatement(conditions)
+
+	expectedStmt := " WHERE age > $1 AND name = $2"
+	if stmt != expectedStmt {
+		t.Errorf("Expected statement to be '%s', got '%s'", expectedStmt, stmt)
+	}
+}
+
+func TestBuildParameters(t *testing.T) {
+	qb := QueryBuilder{}
+	parameters := ClauseMap{"age:>": 30, "name:=": "John Doe"}
+
+	params := qb.buildParameters(parameters)
+
+	expectedParams := []interface{}{30, "John Doe"}
+	if !reflect.DeepEqual(params, expectedParams) {
+		t.Errorf("Expected parameters to be %v, got %v", expectedParams, params)
+	}
+}
+
+func TestBuildReturnedColumns(t *testing.T) {
+	qb := QueryBuilder{}
+	fields := []string{"id", "name", "email"}
+
+	stmt := qb.buildReturnedColumns(fields)
+
+	expectedStmt := "id, name, email"
+	if stmt != expectedStmt {
+		t.Errorf("Expected statement to be '%s', got '%s'", expectedStmt, stmt)
+	}
+}

--- a/pkg/querybuilder/querybuilder_test.go
+++ b/pkg/querybuilder/querybuilder_test.go
@@ -15,14 +15,15 @@ func TestSetBaseTable(t *testing.T) {
 }
 
 func TestInsertQueryBuilder(t *testing.T) {
+	values := append(Clauses{}, Clause{ColumnName: "name", Value: "John Doe"}, Clause{ColumnName: "age", Value: 30})
 	qb := QueryBuilder{}
-	insertQB := qb.SetBaseTable("users").Insert(ClauseMap{"name": "John Doe", "age": 30}).Returning("id", "created_at")
+	insertQB := qb.SetBaseTable("users").Insert(values).Returning("id", "created_at")
 
 	if insertQB.table != "users" {
 		t.Errorf("Expected table to be 'users', got %s", insertQB.table)
 	}
 
-	expectedValues := ClauseMap{"name": "John Doe", "age": 30}
+	expectedValues := append(Clauses{}, Clause{ColumnName: "name", Value: "John Doe"}, Clause{ColumnName: "age", Value: 30})
 	if !reflect.DeepEqual(insertQB.values, expectedValues) {
 		t.Errorf("Expected values to be %v, got %v", expectedValues, insertQB.values)
 	}
@@ -49,10 +50,10 @@ func TestDeleteQueryBuilder(t *testing.T) {
 
 func TestAddCondition(t *testing.T) {
 	qb := QueryBuilder{}
-	conditions := make(ClauseMap)
+	conditions := make(Clauses, 0)
 	qb.addCondition("age", 30, "=", &conditions)
 
-	expectedConditions := ClauseMap{"age:=": 30}
+	expectedConditions := append(Clauses{}, Clause{ColumnName: "age:=", Value: 30})
 	if !reflect.DeepEqual(conditions, expectedConditions) {
 		t.Errorf("Expected conditions to be %v, got %v", expectedConditions, conditions)
 	}
@@ -61,7 +62,10 @@ func TestAddCondition(t *testing.T) {
 func TestBuildValuesStatement(t *testing.T) {
 	qb := QueryBuilder{}
 	qb.preparedVariableOffset = 0
-	values := ClauseMap{"name": "John Doe", "age": 30}
+	values := make(Clauses, 0)
+	values = append(values,
+		Clause{ColumnName: "age:>", Value: 30},
+		Clause{ColumnName: "name:=", Value: "John Doe"})
 
 	stmt := qb.buildValuesStatement(values)
 
@@ -73,7 +77,10 @@ func TestBuildValuesStatement(t *testing.T) {
 
 func TestBuildConditionalStatement(t *testing.T) {
 	qb := QueryBuilder{}
-	conditions := ClauseMap{"age:>": 30, "name:=": "John Doe"}
+	conditions := make(Clauses, 0)
+	conditions = append(conditions,
+		Clause{ColumnName: "age:>", Value: 30},
+		Clause{ColumnName: "name:=", Value: "John Doe"})
 
 	stmt := qb.buildConditionalStatement(conditions)
 
@@ -85,7 +92,10 @@ func TestBuildConditionalStatement(t *testing.T) {
 
 func TestBuildParameters(t *testing.T) {
 	qb := QueryBuilder{}
-	parameters := ClauseMap{"age:>": 30, "name:=": "John Doe"}
+	parameters := make(Clauses, 0)
+	parameters = append(parameters,
+		Clause{ColumnName: "age:>", Value: 30},
+		Clause{ColumnName: "name:=", Value: "John Doe"})
 
 	params := qb.buildParameters(parameters)
 

--- a/pkg/querybuilder/select.go
+++ b/pkg/querybuilder/select.go
@@ -12,7 +12,7 @@ type SelectQueryBuilder struct {
 
 	fields     []string
 	table      string
-	conditions ClauseMap
+	conditions Clauses
 
 	sortDirection string
 	sortColumn    string

--- a/pkg/querybuilder/select_test.go
+++ b/pkg/querybuilder/select_test.go
@@ -1,0 +1,147 @@
+package querybuilder
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSelectQueryBuilder_SetBaseTable(t *testing.T) {
+	qb := QueryBuilder{}
+	query, err := qb.SetBaseTable("users").Select("id", "name").buildQuery()
+	if err != nil {
+		t.Fatalf("Unexpected error when building select query, got %s", err)
+	}
+
+	if *query != "SELECT id, name FROM users" {
+		t.Fatalf("Expected query was not generated got: %s", *query)
+	}
+}
+
+func TestSelectQueryBuilder_From(t *testing.T) {
+	qb := QueryBuilder{}
+	selectQB := qb.Select("id", "name").From("users")
+
+	if selectQB.table != "users" {
+		t.Errorf("Expected table to be 'users', got %s", selectQB.table)
+	}
+	query, err := selectQB.buildQuery()
+	if err != nil {
+		t.Fatalf("Unexpected error when building select query, got %s", err)
+	}
+
+	if *query != "SELECT id, name FROM users" {
+		t.Fatalf("Expected query was not generated got: %s", *query)
+	}
+}
+
+func TestSelectQueryBuilder_NoTableSpecified(t *testing.T) {
+	qb := QueryBuilder{}
+	selectQB := qb.Select("id", "name")
+
+	if selectQB.table != "" {
+		t.Errorf("Expected table to be empty, got %s", selectQB.table)
+	}
+	query, err := selectQB.buildQuery()
+	if query != nil {
+		t.Fatalf("Expected nil query, got %s", *query)
+	}
+
+	if err == nil {
+		t.Fatalf("Expected table error, got nil")
+	}
+}
+
+func TestSelectQueryBuilder_NoFieldsSpecified(t *testing.T) {
+	qb := QueryBuilder{}
+	selectQB := qb.Select().From("users")
+
+	if selectQB.table != "users" {
+		t.Errorf("Expected table to be 'users', got %s", selectQB.table)
+	}
+	query, err := selectQB.buildQuery()
+	if query != nil {
+		t.Fatalf("Expected nil query, got %s", *query)
+	}
+
+	if err == nil {
+		t.Fatalf("Expected fields error, got nil")
+	}
+}
+
+func TestSelectQueryBuilder_LeftJoin(t *testing.T) {
+	qb := QueryBuilder{}
+	selectQB := qb.Select("id", "name").From("users").LeftJoin("orders", "id", "user_id")
+
+	if selectQB.leftJoinTable != "orders" {
+		t.Errorf("Expected left join table to be 'orders', got %s", selectQB.leftJoinTable)
+	}
+
+	if selectQB.leftJoinOwnKey != "id" || selectQB.leftJoinForeignKey != "user_id" {
+		t.Errorf("Expected join keys to be 'id' and 'user_id', got %s and %s", selectQB.leftJoinOwnKey, selectQB.leftJoinForeignKey)
+	}
+
+	query, err := selectQB.buildQuery()
+	if err != nil {
+		t.Fatalf("Unexpected error when building select query, got %s", err)
+	}
+
+	if *query != "SELECT id, name FROM users LEFT JOIN orders ON users.id = orders.user_id" {
+		t.Fatalf("Expected query was not generated got: %s", *query)
+	}
+}
+
+func TestSelectQueryBuilder_OrderBy(t *testing.T) {
+	qb := QueryBuilder{}
+	selectQB := qb.Select("id", "name").From("users").OrderBy("id", "DESC")
+
+	if selectQB.sortColumn != "id" || selectQB.sortDirection != "DESC" {
+		t.Errorf("Expected order by 'id DESC', got %s %s", selectQB.sortColumn, selectQB.sortDirection)
+	}
+
+	query, err := selectQB.buildQuery()
+	if err != nil {
+		t.Fatalf("Unexpected error when building select query, got %s", err)
+	}
+
+	if *query != "SELECT id, name FROM users ORDER BY id DESC" {
+		t.Fatalf("Expected query was not generated got: %s", *query)
+	}
+}
+
+func TestSelectQueryBuilder_WhereEqual(t *testing.T) {
+	qb := QueryBuilder{}
+	selectQB := qb.Select("id", "name").From("users").WhereEqual("age", 30)
+
+	expectedConditions := ClauseMap{"age:=": 30}
+	if !reflect.DeepEqual(selectQB.conditions, expectedConditions) {
+		t.Errorf("Expected conditions to be %v, got %v", expectedConditions, selectQB.conditions)
+	}
+
+	query, err := selectQB.buildQuery()
+	if err != nil {
+		t.Fatalf("Unexpected error when building select query, got %s", err)
+	}
+
+	if *query != "SELECT id, name FROM users WHERE age = $1" {
+		t.Fatalf("Expected query was not generated got: %s", *query)
+	}
+}
+
+func TestSelectQueryBuilder_WhereEqual_Null(t *testing.T) {
+	qb := QueryBuilder{}
+	selectQB := qb.Select("id", "name").From("users").WhereEqual("age", 30).WhereEqual("deleted_at", nil).WhereEqual("category", "admin")
+
+	expectedConditions := ClauseMap{"age:=": 30, "deleted_at:IS NULL": nil, "category:=": "admin"}
+	if !reflect.DeepEqual(selectQB.conditions, expectedConditions) {
+		t.Errorf("Expected conditions to be %v, got %v", expectedConditions, selectQB.conditions)
+	}
+
+	query, err := selectQB.buildQuery()
+	if err != nil {
+		t.Fatalf("Unexpected error when building select query, got %s", err)
+	}
+
+	if *query != "SELECT id, name FROM users WHERE age = $1 AND deleted_at IS NULL AND category = $2" {
+		t.Fatalf("Expected query was not generated got: %s", *query)
+	}
+}

--- a/pkg/querybuilder/select_test.go
+++ b/pkg/querybuilder/select_test.go
@@ -112,7 +112,7 @@ func TestSelectQueryBuilder_WhereEqual(t *testing.T) {
 	qb := QueryBuilder{}
 	selectQB := qb.Select("id", "name").From("users").WhereEqual("age", 30)
 
-	expectedConditions := ClauseMap{"age:=": 30}
+	expectedConditions := append(Clauses{}, Clause{ColumnName: "age:=", Value: 30})
 	if !reflect.DeepEqual(selectQB.conditions, expectedConditions) {
 		t.Errorf("Expected conditions to be %v, got %v", expectedConditions, selectQB.conditions)
 	}
@@ -131,7 +131,11 @@ func TestSelectQueryBuilder_WhereEqual_Null(t *testing.T) {
 	qb := QueryBuilder{}
 	selectQB := qb.Select("id", "name").From("users").WhereEqual("age", 30).WhereEqual("deleted_at", nil).WhereEqual("category", "admin")
 
-	expectedConditions := ClauseMap{"age:=": 30, "deleted_at:IS NULL": nil, "category:=": "admin"}
+	expectedConditions := append(Clauses{},
+		Clause{ColumnName: "age:=", Value: 30},
+		Clause{ColumnName: "deleted_at:IS NULL"},
+		Clause{ColumnName: "category:=", Value: "admin"},
+	)
 	if !reflect.DeepEqual(selectQB.conditions, expectedConditions) {
 		t.Errorf("Expected conditions to be %v, got %v", expectedConditions, selectQB.conditions)
 	}

--- a/pkg/querybuilder/update.go
+++ b/pkg/querybuilder/update.go
@@ -9,8 +9,8 @@ import (
 type UpdateQueryBuilder struct {
 	queryBuilder QueryBuilder
 	table        string
-	values       ClauseMap
-	conditions   ClauseMap
+	values       Clauses
+	conditions   Clauses
 	fields       []string
 }
 

--- a/pkg/querybuilder/update.go
+++ b/pkg/querybuilder/update.go
@@ -11,39 +11,33 @@ type UpdateQueryBuilder struct {
 	table        string
 	values       ClauseMap
 	conditions   ClauseMap
-}
-
-func (q UpdateQueryBuilder) buildColumnUpdateStatement() string {
-	keys := make([]string, 0, len(q.values))
-	for k := range q.values {
-		keys = append(keys, k)
-	}
-
-	stmt := ""
-
-	if len(keys) != 0 {
-		stmt += " SET"
-
-		for i, column := range keys {
-			if i > 0 {
-				stmt += ","
-			}
-			stmt += fmt.Sprintf(" %s = $%d", column, i+1)
-		}
-	}
-
-	return stmt
+	fields       []string
 }
 
 func (q UpdateQueryBuilder) buildPreparedStatementValues() []interface{} {
+	values := make([]interface{}, 0)
+
+	if len(q.queryBuilder.commonTableExpressions) > 0 {
+		for _, cte := range q.queryBuilder.commonTableExpressions {
+			values = append(values, cte.buildPreparedStatementValues()...)
+		}
+	}
+
 	updateValues := q.queryBuilder.buildParameters(q.values)
 	conditionValues := q.queryBuilder.buildParameters(q.conditions)
 
-	return append(updateValues, conditionValues...)
+	values = append(values, updateValues...)
+	values = append(values, conditionValues...)
+	return values
 }
 
 func (q UpdateQueryBuilder) WhereEqual(column string, value interface{}) UpdateQueryBuilder {
 	q.queryBuilder.addCondition(column, value, "=", &q.conditions)
+	return q
+}
+
+func (q UpdateQueryBuilder) Returning(fields ...string) UpdateQueryBuilder {
+	q.fields = fields
 	return q
 }
 
@@ -54,8 +48,13 @@ func (q UpdateQueryBuilder) buildQuery() (*string, error) {
 	}
 
 	query := fmt.Sprintf("UPDATE %s", q.table)
-	query += q.buildColumnUpdateStatement()
-	query += q.queryBuilder.buildConditionalStatement(q.conditions, len(q.values))
+	query += q.queryBuilder.buildColumnUpdateStatement(q.values)
+	query += q.queryBuilder.buildConditionalStatement(q.conditions)
+
+	if len(q.fields) > 0 {
+		returnedColumns := q.queryBuilder.buildReturnedColumns(q.fields)
+		query += fmt.Sprintf(" RETURNING %s", returnedColumns)
+	}
 
 	return &query, nil
 }

--- a/pkg/querybuilder/update_test.go
+++ b/pkg/querybuilder/update_test.go
@@ -7,10 +7,10 @@ import (
 
 func TestUpdateQueryBuilder_Fails_Without_Where(t *testing.T) {
 	qb := QueryBuilder{}
-	values := ClauseMap{
-		"name": "John",
-		"age":  31,
-	}
+	values := append(Clauses{},
+		Clause{ColumnName: "name", Value: "John"},
+		Clause{ColumnName: "age", Value: 31},
+	)
 
 	updateQB := qb.Update(values)
 
@@ -23,14 +23,14 @@ func TestUpdateQueryBuilder_Fails_Without_Where(t *testing.T) {
 
 func TestUpdateQueryBuilder_WhereEqual(t *testing.T) {
 	qb := QueryBuilder{}
-	values := ClauseMap{
-		"name": "John",
-		"age":  31,
-	}
+	values := append(Clauses{},
+		Clause{ColumnName: "name", Value: "John"},
+		Clause{ColumnName: "age", Value: 31},
+	)
 
 	updateQB := qb.SetBaseTable("users").Update(values).WhereEqual("id", 1)
 
-	expectedConditions := ClauseMap{"id:=": 1}
+	expectedConditions := append(Clauses{}, Clause{ColumnName: "id:=", Value: 1})
 	if !reflect.DeepEqual(updateQB.conditions, expectedConditions) {
 		t.Errorf("Expected conditions to be %v, got %v", expectedConditions, updateQB.conditions)
 	}
@@ -51,9 +51,7 @@ func TestUpdateQueryBuilder_WhereEqual(t *testing.T) {
 
 func TestUpdateQueryBuilder_NoTable(t *testing.T) {
 	qb := QueryBuilder{}
-	values := ClauseMap{
-		"name": "John",
-	}
+	values := append(Clauses{}, Clause{ColumnName: "name", Value: "John"})
 
 	updateQB := qb.Update(values).WhereEqual("id", 1)
 
@@ -66,10 +64,10 @@ func TestUpdateQueryBuilder_NoTable(t *testing.T) {
 
 func TestUpdateQueryBuilder_Returning(t *testing.T) {
 	qb := QueryBuilder{}
-	values := ClauseMap{
-		"name": "John",
-		"age":  31,
-	}
+	values := append(Clauses{},
+		Clause{ColumnName: "name", Value: "John"},
+		Clause{ColumnName: "age", Value: 31},
+	)
 
 	updateQB := qb.SetBaseTable("users").Update(values).Returning("id", "updated_at")
 

--- a/pkg/querybuilder/update_test.go
+++ b/pkg/querybuilder/update_test.go
@@ -1,0 +1,85 @@
+package querybuilder
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUpdateQueryBuilder_Fails_Without_Where(t *testing.T) {
+	qb := QueryBuilder{}
+	values := ClauseMap{
+		"name": "John",
+		"age":  31,
+	}
+
+	updateQB := qb.Update(values)
+
+	_, err := updateQB.buildQuery()
+
+	if err == nil {
+		t.Fatalf("Expected error for missing conditions, got nil")
+	}
+}
+
+func TestUpdateQueryBuilder_WhereEqual(t *testing.T) {
+	qb := QueryBuilder{}
+	values := ClauseMap{
+		"name": "John",
+		"age":  31,
+	}
+
+	updateQB := qb.SetBaseTable("users").Update(values).WhereEqual("id", 1)
+
+	expectedConditions := ClauseMap{"id:=": 1}
+	if !reflect.DeepEqual(updateQB.conditions, expectedConditions) {
+		t.Errorf("Expected conditions to be %v, got %v", expectedConditions, updateQB.conditions)
+	}
+
+	query, err := updateQB.buildQuery()
+
+	expectedQuery := "UPDATE users SET name = $1, age = $2 WHERE id = $3"
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if *query != expectedQuery {
+
+		t.Errorf("Expected query to be '%s', got '%s'", expectedQuery, *query)
+
+	}
+
+}
+
+func TestUpdateQueryBuilder_NoTable(t *testing.T) {
+	qb := QueryBuilder{}
+	values := ClauseMap{
+		"name": "John",
+	}
+
+	updateQB := qb.Update(values).WhereEqual("id", 1)
+
+	_, err := updateQB.buildQuery()
+
+	if err == nil {
+		t.Error("Expected error for missing table, got nil")
+	}
+}
+
+func TestUpdateQueryBuilder_Returning(t *testing.T) {
+	qb := QueryBuilder{}
+	values := ClauseMap{
+		"name": "John",
+		"age":  31,
+	}
+
+	updateQB := qb.SetBaseTable("users").Update(values).Returning("id", "updated_at")
+
+	query, err := updateQB.buildQuery()
+
+	expectedQuery := "UPDATE users SET name = $1, age = $2 RETURNING id, updated_at"
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if *query != expectedQuery {
+		t.Errorf("Expected query to be '%s', got '%s'", expectedQuery, *query)
+	}
+}


### PR DESCRIPTION
## Overview
As prep for adding common table expressions, I'm doing some refactoring and adding tests.

The tests uncovered an interesting issue. My `ClauseMap` data structure which was used throughout the querybuilder was a map. Maps famously do not have a guaranteed iteration order, but unfortunately, I din't know this when I started out on this endeavour. My tests were flakey because the ordering of clauses changed which led to different queries than intended being generated.

I've fixed this with a new `Clauses` data structure which is a slice of type `Clause` which is a tuple of the name and value of the clause.

## Changes
The changes in this PR are broken into three main parts (and correspond to the commits if it’s easier to review that way!). 

### 1. Move parameter placeholder generation
The first part is moving functions that generate parameterised statements or parts of statements into the main querybuilder.

By parameterised statements, I’m referring to parts of the generated SQL of the form `$1, $2`. This would allow the parent querybuilder keep track of the number of parameters that will exist in the final statement and allow us have the correct numbers when the statement is built. Prior to this change, each builder (i.e `Select`, `Insert` etc) used the count of parameters it had (e.g values to insert or conditions) to determine the number to attach to each parameter.

This worked well enough when the queries were self contained, but with common table expressions (CTEs), we could expect to have parameter counts spanning multiple queries. Consider the example below:

```
WITH updated_users AS (
  UPDATE users SET (is_verified) VALUES ($1)             
  WHERE id = $2
  RETURNING id, latest_action, updated_at
) 
SELECT id, email, latest_action, updated_at FROM updated_users
WHERE email = $3
```

A statement like this combines an UPDATE (with 2 parameters) with 
a SELECT (with one parameter) and if each individual builder kept track of it’s parameters we’d end up with an incorrect numbering.

### 2. Add tests
With so much change to the internals of the querybuilder, it felt like a good time to add tests to that package at least.

I’ve done a crash course in testing in Go, so it may well be that these aren’t the best way to write tests in Go, but it feels like it has good coverage for the things I care about. I’ve tested query generation, looking at the internal state of the builders as well as testing the final query it outputs.

Interestingly enough, these tests help me catch a serious issue that might have otherwise stumped me: **Maps do not guarantee iteration order.** This is true in many other languages as well, however with most of my exposure to map like structures coming via JS objects where the [iteration order for non-numeric properties is in insertion order](https://stackoverflow.com/a/75236473), I was relying on the same kind of behaviour without realising it. In fact, having researched it some more, it turns out that had I relied on this behaviour for numeric keys in JavaScript, it would have also been broken! So good to learn :)

In this case, this bug manifested in the tests being flakey with passes sometimes and failures sometimes on exactly the same test with the clauses sometimes coming in the correct order and sometimes not.

This leads to the third change I had to make, which was rewriting the clause data structure to something that respected insertion order.

### 3. Update data structure for parameters
Throughout the querybuilder, I made use of a data structure of key value pairs that represented either parameters for either insert/update values or conditionals. It relies on being able to retrieve items in the order they were inserted in order to correctly construct the query. In thinking about this a bit more, while I need to maintain key value pairs for individual clauses, the collection of those clauses can be maintained as a simple list (or slice in Golang). I’ve now rewritten the querybuilder to use this structure and updated the tests, which seem to no long flake!

### 4. Update usage of querybuilder in api package
Given the widespread changes, updated use of the querybuilder across the app.

## Follow Up
Up next after this is adding CTE support and updating the actual API to use that functionality!