### PR TITLE
Feat/add support for common table expressions

### DIFF
--- a/internal/data/roles.go
+++ b/internal/data/roles.go
@@ -131,6 +131,25 @@ func (r RoleModel) Update(role *Role) error {
 		FROM updated_role
 		LEFT JOIN companies ON updated_role.companyId = companies.id;
 	`
+	values := querybuilder.Clauses{
+		querybuilder.Clause{ColumnName: "startDate", Value: role.StartDate},
+		querybuilder.Clause{ColumnName: "endDate", Value: role.EndDate},
+		querybuilder.Clause{ColumnName: "title", Value: role.Title},
+		querybuilder.Clause{ColumnName: "subtitle", Value: role.Subtitle},
+		querybuilder.Clause{ColumnName: "slug", Value: role.Slug},
+		querybuilder.Clause{ColumnName: "description", Value: role.Description},
+		querybuilder.Clause{ColumnName: "skills", Value: role.Skills},
+		querybuilder.Clause{ColumnName: "companyId", Value: role.CompanyId},
+		querybuilder.Clause{ColumnName: "updatedAt", Value: role.UpdatedAt},
+	}
+
+	r.Query.With(
+		r.Query.SetBaseTable("roles").Update(values).WhereEqual("id", role.ID).Returning("*"), "updated_role").
+		Select(
+			"updated_role.updatedAt AS updatedAt",
+			"companies.id AS companyId",
+			"companies.name AS company",
+			"companies.icon AS companyIcon").From("updated_role").LeftJoin("companies", "id", "companyId").QueryRow()
 
 	args := []interface{}{role.StartDate, role.EndDate, role.Title, role.Subtitle, role.Slug, role.Description, pq.Array(role.Skills), role.CompanyId, role.ID}
 	return r.DB.QueryRow(query, args...).Scan(&role.UpdatedAt, &role.CompanyId, &role.Company, &role.CompanyIcon)

--- a/pkg/querybuilder/delete.go
+++ b/pkg/querybuilder/delete.go
@@ -7,12 +7,12 @@ import (
 )
 
 type DeleteQueryBuilder struct {
-	queryBuilder QueryBuilder
+	queryBuilder *QueryBuilder
 	table        string
 	conditions   Clauses
 }
 
-func (q DeleteQueryBuilder) buildQuery() (*string, error) {
+func (q *DeleteQueryBuilder) buildQuery() (*string, error) {
 	if len(q.conditions) == 0 {
 		err := errors.New("Incorrectly formatted query. Ensure fields are set")
 		return nil, err
@@ -29,12 +29,12 @@ func (q DeleteQueryBuilder) buildQuery() (*string, error) {
 	return &query, nil
 }
 
-func (q DeleteQueryBuilder) WhereEqual(column string, value interface{}) DeleteQueryBuilder {
+func (q *DeleteQueryBuilder) WhereEqual(column string, value interface{}) *DeleteQueryBuilder {
 	q.queryBuilder.addCondition(column, value, "=", &q.conditions)
 	return q
 }
 
-func (q DeleteQueryBuilder) Exec() (sql.Result, error) {
+func (q *DeleteQueryBuilder) Exec() (sql.Result, error) {
 	query, err := q.buildQuery()
 	if err != nil {
 		return nil, err

--- a/pkg/querybuilder/insert.go
+++ b/pkg/querybuilder/insert.go
@@ -13,6 +13,13 @@ type InsertQueryBuilder struct {
 	fields       []string
 }
 
+func (q *InsertQueryBuilder) buildPreparedStatementValues() []interface{} {
+	values := q.queryBuilder.buildCommonTableExpressionParameters()
+	values = append(values, q.queryBuilder.buildParameters(q.values))
+
+	return values
+}
+
 func (q *InsertQueryBuilder) buildColumnNameStatement() string {
 	stmt := ""
 
@@ -59,7 +66,7 @@ func (q *InsertQueryBuilder) Query() (*sql.Rows, error) {
 	if err != nil {
 		return nil, err
 	}
-	values := q.queryBuilder.buildParameters(q.values)
+	values := q.buildPreparedStatementValues()
 	return q.queryBuilder.DB.Query(*query, values...)
 }
 
@@ -69,7 +76,7 @@ func (q *InsertQueryBuilder) QueryRow() (*sql.Row, error) {
 		return nil, err
 	}
 
-	values := q.queryBuilder.buildParameters(q.values)
+	values := q.buildPreparedStatementValues()
 	return q.queryBuilder.DB.QueryRow(*query, values...), nil
 }
 
@@ -79,6 +86,6 @@ func (q *InsertQueryBuilder) Exec() (sql.Result, error) {
 		return nil, err
 	}
 
-	values := q.queryBuilder.buildParameters(q.values)
+	values := q.buildPreparedStatementValues()
 	return q.queryBuilder.DB.Exec(*query, values...)
 }

--- a/pkg/querybuilder/insert.go
+++ b/pkg/querybuilder/insert.go
@@ -7,13 +7,13 @@ import (
 )
 
 type InsertQueryBuilder struct {
-	queryBuilder QueryBuilder
+	queryBuilder *QueryBuilder
 	table        string
 	values       Clauses
 	fields       []string
 }
 
-func (q InsertQueryBuilder) buildColumnNameStatement() string {
+func (q *InsertQueryBuilder) buildColumnNameStatement() string {
 	stmt := ""
 
 	if len(q.values) != 0 {
@@ -28,7 +28,7 @@ func (q InsertQueryBuilder) buildColumnNameStatement() string {
 	return stmt
 }
 
-func (q InsertQueryBuilder) buildQuery() (*string, error) {
+func (q *InsertQueryBuilder) buildQuery() (*string, error) {
 	if len(q.values) == 0 {
 		err := errors.New("Incorrectly formatted query. Ensure fields are set")
 		return nil, err
@@ -49,12 +49,12 @@ func (q InsertQueryBuilder) buildQuery() (*string, error) {
 	return &query, nil
 }
 
-func (q InsertQueryBuilder) Returning(fields ...string) InsertQueryBuilder {
+func (q *InsertQueryBuilder) Returning(fields ...string) *InsertQueryBuilder {
 	q.fields = fields
 	return q
 }
 
-func (q InsertQueryBuilder) Query() (*sql.Rows, error) {
+func (q *InsertQueryBuilder) Query() (*sql.Rows, error) {
 	query, err := q.buildQuery()
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ func (q InsertQueryBuilder) Query() (*sql.Rows, error) {
 	return q.queryBuilder.DB.Query(*query, values...)
 }
 
-func (q InsertQueryBuilder) QueryRow() (*sql.Row, error) {
+func (q *InsertQueryBuilder) QueryRow() (*sql.Row, error) {
 	query, err := q.buildQuery()
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func (q InsertQueryBuilder) QueryRow() (*sql.Row, error) {
 	return q.queryBuilder.DB.QueryRow(*query, values...), nil
 }
 
-func (q InsertQueryBuilder) Exec() (sql.Result, error) {
+func (q *InsertQueryBuilder) Exec() (sql.Result, error) {
 	query, err := q.buildQuery()
 	if err != nil {
 		return nil, err

--- a/pkg/querybuilder/insert_test.go
+++ b/pkg/querybuilder/insert_test.go
@@ -8,7 +8,7 @@ func TestInsertQueryBuilder_buildColumnNameStatement(t *testing.T) {
 	qb := QueryBuilder{}
 	values := append(Clauses{}, Clause{ColumnName: "name", Value: "John"}, Clause{ColumnName: "age", Value: 30})
 
-	insertQB := InsertQueryBuilder{queryBuilder: qb, values: values}
+	insertQB := InsertQueryBuilder{queryBuilder: &qb, values: values}
 
 	columnStmt := insertQB.buildColumnNameStatement()
 

--- a/pkg/querybuilder/querybuilder.go
+++ b/pkg/querybuilder/querybuilder.go
@@ -148,3 +148,31 @@ func (q *QueryBuilder) buildReturnedColumns(fields []string) string {
 
 	return stmt
 }
+
+func (q *QueryBuilder) buildCommonTableExpressionParameters() []interface{} {
+	values := make([]interface{}, 0)
+
+	if len(q.commonTableExpressions) > 0 {
+		for _, cte := range q.commonTableExpressions {
+			values = append(values, cte.Builder.buildPreparedStatementValues()...)
+		}
+	}
+
+	return values
+}
+
+func (q *QueryBuilder) buildCommonTableExpressions() (string, error) {
+	stmt := ""
+
+	if len(q.commonTableExpressions) > 0 {
+		for _, cte := range q.commonTableExpressions {
+			query, err := cte.Builder.buildQuery()
+			if err != nil {
+				return "", err
+			}
+			stmt += fmt.Sprintf("WITH %s AS (%s) ", cte.Table, *query)
+		}
+	}
+
+	return stmt, nil
+}

--- a/pkg/querybuilder/querybuilder.go
+++ b/pkg/querybuilder/querybuilder.go
@@ -29,23 +29,23 @@ func (q *QueryBuilder) SetBaseTable(table string) *QueryBuilder {
 	return q
 }
 
-func (q QueryBuilder) Select(fields ...string) SelectQueryBuilder {
-	return SelectQueryBuilder{queryBuilder: q, table: q.table, fields: fields}
+func (q *QueryBuilder) Select(fields ...string) *SelectQueryBuilder {
+	return &SelectQueryBuilder{queryBuilder: q, table: q.table, fields: fields}
 }
 
-func (q QueryBuilder) Update(values Clauses) UpdateQueryBuilder {
-	return UpdateQueryBuilder{queryBuilder: q, table: q.table, values: values}
+func (q *QueryBuilder) Update(values Clauses) *UpdateQueryBuilder {
+	return &UpdateQueryBuilder{queryBuilder: q, table: q.table, values: values}
 }
 
-func (q QueryBuilder) Insert(values Clauses) InsertQueryBuilder {
-	return InsertQueryBuilder{queryBuilder: q, table: q.table, values: values}
+func (q *QueryBuilder) Insert(values Clauses) *InsertQueryBuilder {
+	return &InsertQueryBuilder{queryBuilder: q, table: q.table, values: values}
 }
 
-func (q QueryBuilder) Delete() DeleteQueryBuilder {
-	return DeleteQueryBuilder{queryBuilder: q, table: q.table}
+func (q *QueryBuilder) Delete() *DeleteQueryBuilder {
+	return &DeleteQueryBuilder{queryBuilder: q, table: q.table}
 }
 
-func (q QueryBuilder) With(query CommonQueryBuilder, name string) QueryBuilder {
+func (q *QueryBuilder) With(query CommonQueryBuilder, name string) *QueryBuilder {
 	if q.commonTableExpressions == nil {
 		q.commonTableExpressions = make([]CommonQueryBuilder, 0)
 	}

--- a/pkg/querybuilder/querybuilder.go
+++ b/pkg/querybuilder/querybuilder.go
@@ -12,11 +12,16 @@ type Clause struct {
 }
 type Clauses []Clause
 
+type CommonQuery struct {
+	Builder CommonQueryBuilder
+	Table   string
+}
+
 type QueryBuilder struct {
 	DB                     *sql.DB
 	table                  string
 	preparedVariableOffset int
-	commonTableExpressions []CommonQueryBuilder
+	commonTableExpressions []CommonQuery
 }
 
 type CommonQueryBuilder interface {

--- a/pkg/querybuilder/querybuilder.go
+++ b/pkg/querybuilder/querybuilder.go
@@ -51,12 +51,13 @@ func (q *QueryBuilder) Delete() *DeleteQueryBuilder {
 }
 
 func (q *QueryBuilder) With(query CommonQueryBuilder, name string) *QueryBuilder {
-	if q.commonTableExpressions == nil {
-		q.commonTableExpressions = make([]CommonQueryBuilder, 0)
+	clonedQueryBuilder := *q
+	if clonedQueryBuilder.commonTableExpressions == nil {
+		clonedQueryBuilder.commonTableExpressions = make([]CommonQuery, 0)
 	}
 
-	q.commonTableExpressions = append(q.commonTableExpressions, query)
-	return q
+	clonedQueryBuilder.commonTableExpressions = append(q.commonTableExpressions, CommonQuery{Builder: query, Table: name})
+	return &clonedQueryBuilder
 }
 
 func (q *QueryBuilder) addCondition(column string, value interface{}, comparer string, conditions *Clauses) {

--- a/pkg/querybuilder/select.go
+++ b/pkg/querybuilder/select.go
@@ -8,7 +8,7 @@ import (
 )
 
 type SelectQueryBuilder struct {
-	queryBuilder QueryBuilder
+	queryBuilder *QueryBuilder
 
 	fields     []string
 	table      string
@@ -22,12 +22,12 @@ type SelectQueryBuilder struct {
 	leftJoinForeignKey string
 }
 
-func (q SelectQueryBuilder) From(table string) SelectQueryBuilder {
+func (q *SelectQueryBuilder) From(table string) *SelectQueryBuilder {
 	q.table = table
 	return q
 }
 
-func (q SelectQueryBuilder) LeftJoin(table string, ownKey string, foreignKey string) SelectQueryBuilder {
+func (q *SelectQueryBuilder) LeftJoin(table string, ownKey string, foreignKey string) *SelectQueryBuilder {
 	q.leftJoinTable = table
 	q.leftJoinOwnKey = ownKey
 	q.leftJoinForeignKey = foreignKey
@@ -35,14 +35,14 @@ func (q SelectQueryBuilder) LeftJoin(table string, ownKey string, foreignKey str
 	return q
 }
 
-func (q SelectQueryBuilder) OrderBy(column string, sortDirection string) SelectQueryBuilder {
+func (q *SelectQueryBuilder) OrderBy(column string, sortDirection string) *SelectQueryBuilder {
 	q.sortColumn = column
 	q.sortDirection = sortDirection
 
 	return q
 }
 
-func (q SelectQueryBuilder) WhereEqual(column string, value interface{}) SelectQueryBuilder {
+func (q *SelectQueryBuilder) WhereEqual(column string, value interface{}) *SelectQueryBuilder {
 	if value == nil {
 		q.queryBuilder.addCondition(column, nil, "IS NULL", &q.conditions)
 	} else {
@@ -51,7 +51,7 @@ func (q SelectQueryBuilder) WhereEqual(column string, value interface{}) SelectQ
 	return q
 }
 
-func (q SelectQueryBuilder) buildPreparedStatementValues() []interface{} {
+func (q *SelectQueryBuilder) buildPreparedStatementValues() []interface{} {
 	values := make([]interface{}, 0)
 
 	if len(q.queryBuilder.commonTableExpressions) > 0 {
@@ -65,7 +65,7 @@ func (q SelectQueryBuilder) buildPreparedStatementValues() []interface{} {
 	return values
 }
 
-func (q SelectQueryBuilder) buildQuery() (*string, error) {
+func (q *SelectQueryBuilder) buildQuery() (*string, error) {
 	if len(q.fields) == 0 || q.table == "" {
 		err := errors.New("Incorrectly formatted query. Ensure fields and base tables are set")
 		return nil, err
@@ -88,7 +88,7 @@ func (q SelectQueryBuilder) buildQuery() (*string, error) {
 	return &query, nil
 }
 
-func (q SelectQueryBuilder) Query() (*sql.Rows, error) {
+func (q *SelectQueryBuilder) Query() (*sql.Rows, error) {
 	query, err := q.buildQuery()
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ func (q SelectQueryBuilder) Query() (*sql.Rows, error) {
 	return q.queryBuilder.DB.Query(*query)
 }
 
-func (q SelectQueryBuilder) QueryRow() (*sql.Row, error) {
+func (q *SelectQueryBuilder) QueryRow() (*sql.Row, error) {
 	query, err := q.buildQuery()
 	if err != nil {
 		return nil, err

--- a/pkg/querybuilder/select_test.go
+++ b/pkg/querybuilder/select_test.go
@@ -122,8 +122,9 @@ func TestSelectQueryBuilder_WhereEqual(t *testing.T) {
 		t.Fatalf("Unexpected error when building select query, got %s", err)
 	}
 
-	if *query != "SELECT id, name FROM users WHERE age = $1" {
-		t.Fatalf("Expected query was not generated got: %s", *query)
+	expected := "SELECT id, name FROM users WHERE age = $1"
+	if *query != expected {
+		t.Fatalf("Expected query was not generated\nexpected: %s \ngot: %s", expected, *query)
 	}
 }
 
@@ -145,7 +146,8 @@ func TestSelectQueryBuilder_WhereEqual_Null(t *testing.T) {
 		t.Fatalf("Unexpected error when building select query, got %s", err)
 	}
 
-	if *query != "SELECT id, name FROM users WHERE age = $1 AND deleted_at IS NULL AND category = $2" {
-		t.Fatalf("Expected query was not generated got: %s", *query)
+	expected := "SELECT id, name FROM users WHERE age = $1 AND deleted_at IS NULL AND category = $2"
+	if *query != expected {
+		t.Fatalf("Expected query was not generated\nexpected: %s got: %s", expected, *query)
 	}
 }

--- a/pkg/querybuilder/update.go
+++ b/pkg/querybuilder/update.go
@@ -7,14 +7,14 @@ import (
 )
 
 type UpdateQueryBuilder struct {
-	queryBuilder QueryBuilder
+	queryBuilder *QueryBuilder
 	table        string
 	values       Clauses
 	conditions   Clauses
 	fields       []string
 }
 
-func (q UpdateQueryBuilder) buildPreparedStatementValues() []interface{} {
+func (q *UpdateQueryBuilder) buildPreparedStatementValues() []interface{} {
 	values := make([]interface{}, 0)
 
 	if len(q.queryBuilder.commonTableExpressions) > 0 {
@@ -31,17 +31,17 @@ func (q UpdateQueryBuilder) buildPreparedStatementValues() []interface{} {
 	return values
 }
 
-func (q UpdateQueryBuilder) WhereEqual(column string, value interface{}) UpdateQueryBuilder {
+func (q *UpdateQueryBuilder) WhereEqual(column string, value interface{}) *UpdateQueryBuilder {
 	q.queryBuilder.addCondition(column, value, "=", &q.conditions)
 	return q
 }
 
-func (q UpdateQueryBuilder) Returning(fields ...string) UpdateQueryBuilder {
+func (q *UpdateQueryBuilder) Returning(fields ...string) *UpdateQueryBuilder {
 	q.fields = fields
 	return q
 }
 
-func (q UpdateQueryBuilder) buildQuery() (*string, error) {
+func (q *UpdateQueryBuilder) buildQuery() (*string, error) {
 	if len(q.values) == 0 || q.table == "" {
 		err := errors.New("Incorrectly formatted query. Ensure fields and base tables are set")
 		return nil, err

--- a/pkg/querybuilder/update.go
+++ b/pkg/querybuilder/update.go
@@ -15,13 +15,7 @@ type UpdateQueryBuilder struct {
 }
 
 func (q *UpdateQueryBuilder) buildPreparedStatementValues() []interface{} {
-	values := make([]interface{}, 0)
-
-	if len(q.queryBuilder.commonTableExpressions) > 0 {
-		for _, cte := range q.queryBuilder.commonTableExpressions {
-			values = append(values, cte.buildPreparedStatementValues()...)
-		}
-	}
+	values := q.queryBuilder.buildCommonTableExpressionParameters()
 
 	updateValues := q.queryBuilder.buildParameters(q.values)
 	conditionValues := q.queryBuilder.buildParameters(q.conditions)


### PR DESCRIPTION
## Overview
This change adds support for common table expressions (CTEs). It builds on the change from #3 and now allows CTEs with selects, inserts or updates.

## Changes
As usual changes are broken up by commit if that makes it easier to review. I’ve written here a summary of the changes as well.

### 1. Return references rather than copies in querybuilder methods
Methods on the querybuilder were previously attached to and returned copies of the querybuilder. This wasn't very efficient and in most cases, I wanted to be working with the exact same builder through out the lifetime of that query.

### 2. Enable CTE support on Insert queries
Refactored the Insert queries so that they also support CTEs. Select and Update already had support for this enabled in #3. Delete queries don’t have support for this since they typically don’t return any rows, but I may have to rethink this in the future, we'll see.

### 3. Extract common function for generating parameters and queries for CTES
I've extracted functions for building the query string as well as the array of parameters for common table expressions so that all the querybuilders that implement them can call from the parent. The code was exactly the same across all the implementations and will likely change at the same time as well.

### 4. Add table name support for the common query builder
An oversight in my original design, I've now added the ability to specify a table name for the CTE being created. This name can then be referenced just like any other table name in other queries.

### 5. Add tests for CTEs with Select
I've added tests which construct queries with CTEs (one for each of Insert, Update and Select) with a Select call made to the temporary table afterward. All were hitch free except for the Select one which caused a stack overflow error as both Selects made recursive calls to the same methods and same memory addresses.

### 6. Clone builder for CTEs to prevent stack overflow errors

## Follow up
At this point, I think I have a reasonable base to build out any queries I need and so I'll pivot over the next few weeks to focus on the building out the API functionality.