### PR TITLE
Add agent instructions and directory READMEs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agent Instructions
+
+## Repository Orientation
+- Before making any changes, read the root `README.md` and the `README.md` files in relevant subdirectories (especially under `internal/`) to understand the project layout and data models.
+
+## Commit Guidance
+- When committing changes, use the exact user prompt for the commit message.

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -1,0 +1,6 @@
+# `cmd`
+
+This directory contains the executable entry points for the project. Each subdirectory represents a separate Go binary that can be built and run.
+
+## `api`
+The `api` command hosts the HTTP server that powers the personal website backend. See `cmd/api/README.md` for details about handlers, routing, and configuration requirements.

--- a/cmd/api/README.md
+++ b/cmd/api/README.md
@@ -1,0 +1,10 @@
+# `cmd/api`
+
+This package wires together the HTTP API server. Key files include:
+
+- `main.go`: bootstraps configuration, database connections, and starts the server.
+- `routes.go`: declares the routing table and middleware stack.
+- `handlers.go` and `handler_*.go`: provide request handlers for domain entities such as companies and roles.
+- `helper.go`: shared utilities for responding to requests and managing dependencies.
+
+The command expects the database DSN and authorisation token to be supplied either as flags or via the environment variables `WEBSITE_DB_DSN` and `WEBSITE_AUTH_KEY`.

--- a/internal/README.md
+++ b/internal/README.md
@@ -1,0 +1,6 @@
+# `internal`
+
+Packages in this module are intended for use only within the repository. They hold business logic and data access layers that back the public API.
+
+## `data`
+The `data` package defines the database models and helper functions for persisting entities. Refer to `internal/data/README.md` for entity diagrams and schema details.

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -1,0 +1,6 @@
+# `pkg`
+
+Reusable libraries that could be consumed by other modules live here. These packages should be free of application-specific assumptions so that they remain portable.
+
+## `querybuilder`
+A lightweight SQL query builder used by the data layer. See `pkg/querybuilder/README.md` for an overview of available operations.

--- a/pkg/querybuilder/README.md
+++ b/pkg/querybuilder/README.md
@@ -1,0 +1,10 @@
+# `pkg/querybuilder`
+
+This package provides composable helpers for building SQL statements. The core types expose fluent builders for the standard CRUD operations:
+
+- `select.go` constructs `SELECT` queries with filtering, ordering, and pagination helpers.
+- `insert.go` builds `INSERT` statements with support for returning clauses.
+- `update.go` assembles `UPDATE` queries with conditional sets and filters.
+- `delete.go` creates `DELETE` statements.
+
+See the accompanying tests for usage examples that cover the supported query patterns.


### PR DESCRIPTION
## Summary
- add repository-wide agent guidance for commit messages and onboarding
- document executable, internal, and package directories with targeted README files

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8c0f742e8832cafb7f0974e74a017