### PR TITLE
Add basic notes support

### DIFF
--- a/cmd/api/handler_notes.go
+++ b/cmd/api/handler_notes.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"api.etin.dev/internal/data"
+)
+
+func (app *application) getCreateNotesHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		notes, err := app.models.Notes.GetAll()
+		if err != nil {
+			app.logger.Printf("Error retrieving notes: %s", err)
+			app.writeError(w, http.StatusInternalServerError)
+			return
+		}
+
+		app.writeJSON(w, http.StatusOK, envelope{"notes": notes})
+	case http.MethodPost:
+		if !app.isRequestAuthenticated(r) {
+			app.writeError(w, http.StatusForbidden)
+			return
+		}
+
+		var input struct {
+			Title       string     `json:"title"`
+			Subtitle    string     `json:"subtitle"`
+			Body        string     `json:"body"`
+			PublishedAt *time.Time `json:"publishedAt"`
+		}
+
+		err := app.readJSON(w, r, &input)
+		if err != nil {
+			app.logger.Printf("Could not parse request body: %s", err)
+			app.writeError(w, http.StatusBadRequest)
+			return
+		}
+
+		if input.Title == "" {
+			app.writeError(w, http.StatusBadRequest)
+			return
+		}
+
+		var publishedAt *time.Time
+		if input.PublishedAt != nil {
+			t := *input.PublishedAt
+			publishedAt = &t
+		}
+
+		note := &data.Note{
+			Title:       input.Title,
+			Subtitle:    input.Subtitle,
+			Body:        input.Body,
+			PublishedAt: publishedAt,
+		}
+
+		err = app.models.Notes.Insert(note)
+		if err != nil {
+			app.logger.Printf("Could not create note: %s", err)
+			app.writeError(w, http.StatusBadRequest)
+			return
+		}
+
+		app.writeJSON(w, http.StatusCreated, envelope{"note": note})
+	default:
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	}
+}
+
+func (app *application) getUpdateDeleteNotesHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		app.getNote(w, r)
+	case http.MethodPut:
+		app.updateNote(w, r)
+	case http.MethodDelete:
+		app.deleteNote(w, r)
+	default:
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	}
+}
+
+func (app *application) getNote(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(r.URL.Path[len("/v1/notes/"):], 10, 64)
+	if err != nil {
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	note, err := app.models.Notes.Get(id)
+	if err != nil {
+		app.logger.Printf("Could not retrieve note %d: %s", id, err)
+		app.writeError(w, http.StatusNotFound)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, envelope{"note": note})
+}
+
+func (app *application) updateNote(w http.ResponseWriter, r *http.Request) {
+	if !app.isRequestAuthenticated(r) {
+		app.writeError(w, http.StatusForbidden)
+		return
+	}
+
+	id, err := strconv.ParseInt(r.URL.Path[len("/v1/notes/"):], 10, 64)
+	if err != nil {
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	note, err := app.models.Notes.Get(id)
+	if err != nil {
+		app.logger.Printf("Could not retrieve note %d: %s", id, err)
+		app.writeError(w, http.StatusNotFound)
+		return
+	}
+
+	var input struct {
+		Title       *string    `json:"title"`
+		Subtitle    *string    `json:"subtitle"`
+		Body        *string    `json:"body"`
+		PublishedAt *time.Time `json:"publishedAt"`
+	}
+
+	err = app.readJSON(w, r, &input)
+	if err != nil {
+		app.logger.Printf("Could not parse request body: %s", err)
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	if input.Title != nil {
+		note.Title = *input.Title
+	}
+
+	if input.Subtitle != nil {
+		note.Subtitle = *input.Subtitle
+	}
+
+	if input.Body != nil {
+		note.Body = *input.Body
+	}
+
+	if input.PublishedAt != nil {
+		t := *input.PublishedAt
+		note.PublishedAt = &t
+	}
+
+	err = app.models.Notes.Update(note)
+	if err != nil {
+		app.logger.Printf("Could not update note %d: %s", id, err)
+		app.writeError(w, http.StatusInternalServerError)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, envelope{"note": note})
+}
+
+func (app *application) deleteNote(w http.ResponseWriter, r *http.Request) {
+	if !app.isRequestAuthenticated(r) {
+		app.writeError(w, http.StatusForbidden)
+		return
+	}
+
+	id, err := strconv.ParseInt(r.URL.Path[len("/v1/notes/"):], 10, 64)
+	if err != nil {
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	err = app.models.Notes.Delete(id)
+	if err != nil {
+		app.logger.Printf("Could not delete note %d: %s", id, err)
+		app.writeError(w, http.StatusNotFound)
+		return
+	}
+
+	app.writeJSON(w, http.StatusNoContent, envelope{"note": nil})
+}

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -13,5 +13,8 @@ func (app *application) routes() *http.ServeMux {
 	mux.HandleFunc("/v1/companies", app.getCreateCompaniesHandler)
 	mux.HandleFunc("/v1/companies/", app.getUpdateDeleteCompaniesHandler)
 
+	mux.HandleFunc("/v1/notes", app.getCreateNotesHandler)
+	mux.HandleFunc("/v1/notes/", app.getUpdateDeleteNotesHandler)
+
 	return mux
 }

--- a/internal/data/README.md
+++ b/internal/data/README.md
@@ -125,6 +125,7 @@ CREATE TABLE IF NOT EXISTS notes (
   createdAt  timestamp(0) with time zone NOT NULL DEFAULT NOW(),
   updatedAt timestamp(0) with time zone NOT NULL DEFAULT NOW(),
   deletedAt timestamp(0) with time zone,
+  publishedAt timestamp(0) with time zone,
   title text NOT NULL,
   subtitle text,
   body text
@@ -145,5 +146,23 @@ CREATE TABLE IF NOT EXISTS item_notes (
   noteId bigint NOT NULL,
   itemId bigint NOT NULL,
   itemType item_type NOT NULL
+);
+
+```
+
+## Notes table migration
+
+To create the standalone table that powers the notes feature, apply the following SQL:
+
+```sql
+CREATE TABLE IF NOT EXISTS notes (
+  id bigserial PRIMARY KEY,
+  createdAt  timestamp(0) with time zone NOT NULL DEFAULT NOW(),
+  updatedAt timestamp(0) with time zone NOT NULL DEFAULT NOW(),
+  deletedAt timestamp(0) with time zone,
+  publishedAt timestamp(0) with time zone,
+  title text NOT NULL,
+  subtitle text,
+  body text
 );
 ```

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -9,12 +9,14 @@ import (
 type Models struct {
 	Roles     RoleModel
 	Companies CompanyModel
+	Notes     NoteModel
 }
 
 func NewModels(db *sql.DB) Models {
 	return Models{
 		Roles:     RoleModel{DB: db, Query: &querybuilder.QueryBuilder{DB: db}},
 		Companies: CompanyModel{DB: db, Query: &querybuilder.QueryBuilder{DB: db}},
+		Notes:     NoteModel{DB: db, Query: &querybuilder.QueryBuilder{DB: db}},
 	}
 
 }

--- a/internal/data/notes.go
+++ b/internal/data/notes.go
@@ -1,0 +1,261 @@
+package data
+
+import (
+	"database/sql"
+	"errors"
+	"time"
+
+	"api.etin.dev/pkg/querybuilder"
+)
+
+type Note struct {
+	ID          int64      `json:"id"`
+	CreatedAt   time.Time  `json:"-"`
+	UpdatedAt   time.Time  `json:"-"`
+	DeletedAt   *time.Time `json:"-"`
+	PublishedAt *time.Time `json:"publishedAt,omitempty"`
+	Title       string     `json:"title"`
+	Subtitle    string     `json:"subtitle"`
+	Body        string     `json:"body"`
+}
+
+type NoteModel struct {
+	DB    *sql.DB
+	Query *querybuilder.QueryBuilder
+}
+
+func (n NoteModel) Insert(note *Note) error {
+	var publishedAt interface{}
+	if note.PublishedAt != nil {
+		publishedAt = *note.PublishedAt
+	}
+
+	values := querybuilder.Clauses{
+		querybuilder.Clause{ColumnName: "publishedAt", Value: publishedAt},
+		querybuilder.Clause{ColumnName: "title", Value: note.Title},
+		querybuilder.Clause{ColumnName: "subtitle", Value: note.Subtitle},
+		querybuilder.Clause{ColumnName: "body", Value: note.Body},
+	}
+
+	row, err := n.Query.SetBaseTable("notes").Insert(values).Returning("id", "createdAt", "updatedAt", "deletedAt", "publishedAt").QueryRow()
+	if err != nil {
+		return err
+	}
+
+	var deletedAt sql.NullTime
+	var published sql.NullTime
+
+	err = row.Scan(&note.ID, &note.CreatedAt, &note.UpdatedAt, &deletedAt, &published)
+	if err != nil {
+		return err
+	}
+
+	if deletedAt.Valid {
+		note.DeletedAt = &deletedAt.Time
+	}
+
+	if published.Valid {
+		note.PublishedAt = &published.Time
+	} else {
+		note.PublishedAt = nil
+	}
+
+	return nil
+}
+
+func (n NoteModel) Get(id int64) (*Note, error) {
+	if id < 1 {
+		return nil, errors.New("record not found")
+	}
+
+	row, err := n.Query.SetBaseTable("notes").Select(
+		"id",
+		"createdAt",
+		"updatedAt",
+		"deletedAt",
+		"publishedAt",
+		"title",
+		"subtitle",
+		"body",
+	).WhereEqual("deletedAt", nil).WhereEqual("id", id).QueryRow()
+	if err != nil {
+		return nil, err
+	}
+
+	var note Note
+	var deletedAt sql.NullTime
+	var publishedAt sql.NullTime
+
+	err = row.Scan(
+		&note.ID,
+		&note.CreatedAt,
+		&note.UpdatedAt,
+		&deletedAt,
+		&publishedAt,
+		&note.Title,
+		&note.Subtitle,
+		&note.Body,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.New("record not found")
+		}
+		return nil, err
+	}
+
+	if deletedAt.Valid {
+		note.DeletedAt = &deletedAt.Time
+	}
+
+	if publishedAt.Valid {
+		note.PublishedAt = &publishedAt.Time
+	}
+
+	return &note, nil
+}
+
+func (n NoteModel) Update(note *Note) error {
+	var publishedAt interface{}
+	if note.PublishedAt != nil {
+		publishedAt = *note.PublishedAt
+	}
+
+	values := querybuilder.Clauses{
+		querybuilder.Clause{ColumnName: "publishedAt", Value: publishedAt},
+		querybuilder.Clause{ColumnName: "title", Value: note.Title},
+		querybuilder.Clause{ColumnName: "subtitle", Value: note.Subtitle},
+		querybuilder.Clause{ColumnName: "body", Value: note.Body},
+		querybuilder.Clause{ColumnName: "updatedAt", Value: time.Now()},
+	}
+
+	row, err := n.Query.With(
+		n.Query.SetBaseTable("notes").Update(values).WhereEqual("id", note.ID).WhereEqual("deletedAt", nil).Returning("id", "createdAt", "updatedAt", "deletedAt", "publishedAt", "title", "subtitle", "body"),
+		"updated_note",
+	).Select(
+		"updated_note.id",
+		"updated_note.createdAt",
+		"updated_note.updatedAt",
+		"updated_note.deletedAt",
+		"updated_note.publishedAt",
+		"updated_note.title",
+		"updated_note.subtitle",
+		"updated_note.body",
+	).From("updated_note").QueryRow()
+	if err != nil {
+		return err
+	}
+
+	var deletedAt sql.NullTime
+	var published sql.NullTime
+
+	err = row.Scan(
+		&note.ID,
+		&note.CreatedAt,
+		&note.UpdatedAt,
+		&deletedAt,
+		&published,
+		&note.Title,
+		&note.Subtitle,
+		&note.Body,
+	)
+	if err != nil {
+		return err
+	}
+
+	if deletedAt.Valid {
+		note.DeletedAt = &deletedAt.Time
+	} else {
+		note.DeletedAt = nil
+	}
+
+	if published.Valid {
+		note.PublishedAt = &published.Time
+	} else {
+		note.PublishedAt = nil
+	}
+
+	return nil
+}
+
+func (n NoteModel) Delete(id int64) error {
+	if id < 1 {
+		return errors.New("record not found")
+	}
+
+	values := querybuilder.Clauses{
+		querybuilder.Clause{ColumnName: "updatedAt", Value: time.Now()},
+		querybuilder.Clause{ColumnName: "deletedAt", Value: time.Now()},
+	}
+
+	results, err := n.Query.SetBaseTable("notes").Update(values).WhereEqual("id", id).WhereEqual("deletedAt", nil).Exec()
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := results.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return errors.New("record not found")
+	}
+
+	return nil
+}
+
+func (n NoteModel) GetAll() ([]*Note, error) {
+	rows, err := n.Query.SetBaseTable("notes").Select(
+		"id",
+		"createdAt",
+		"updatedAt",
+		"deletedAt",
+		"publishedAt",
+		"title",
+		"subtitle",
+		"body",
+	).WhereEqual("deletedAt", nil).OrderBy("COALESCE(publishedAt, createdAt)", "desc").Query()
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	notes := []*Note{}
+
+	for rows.Next() {
+		var note Note
+		var deletedAt sql.NullTime
+		var publishedAt sql.NullTime
+
+		err := rows.Scan(
+			&note.ID,
+			&note.CreatedAt,
+			&note.UpdatedAt,
+			&deletedAt,
+			&publishedAt,
+			&note.Title,
+			&note.Subtitle,
+			&note.Body,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if deletedAt.Valid {
+			note.DeletedAt = &deletedAt.Time
+		}
+
+		if publishedAt.Valid {
+			note.PublishedAt = &publishedAt.Time
+		}
+
+		notes = append(notes, &note)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return notes, nil
+}


### PR DESCRIPTION
## Summary
- add a Notes model with CRUD helpers for storing note content
- expose HTTP handlers and routes for managing notes
- document the SQL needed to create the notes table, including the publishedAt column

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e8cb741584832cb0127a15d9b631fa