### PR TITLE
Add basic Projects data model and API endpoints

### DIFF
--- a/cmd/api/handler_projects.go
+++ b/cmd/api/handler_projects.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"api.etin.dev/internal/data"
+)
+
+func (app *application) getCreateProjectsHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		projects, err := app.models.Projects.GetAll()
+		if err != nil {
+			app.logger.Printf("Error retrieving projects. Error: %s", err)
+			app.writeError(w, http.StatusInternalServerError)
+			return
+		}
+
+		app.writeJSON(w, http.StatusOK, envelope{"projects": projects})
+	case http.MethodPost:
+		if !app.isRequestAuthenticated(r) {
+			app.writeError(w, http.StatusForbidden)
+			return
+		}
+
+		var input struct {
+			StartDate   time.Time  `json:"startDate"`
+			EndDate     *time.Time `json:"endDate"`
+			Title       string     `json:"title"`
+			Description string     `json:"description"`
+		}
+
+		err := app.readJSON(w, r, &input)
+		if err != nil {
+			app.logger.Printf("Error parsing project payload. Error: %s", err)
+			app.writeError(w, http.StatusBadRequest)
+			return
+		}
+
+		project := &data.Project{
+			StartDate:   input.StartDate,
+			Title:       input.Title,
+			Description: input.Description,
+		}
+
+		if input.EndDate != nil {
+			project.EndDate = input.EndDate
+		}
+
+		err = app.models.Projects.Insert(project)
+		if err != nil {
+			app.logger.Printf("Error creating project. Error: %s", err)
+			app.writeError(w, http.StatusBadRequest)
+			return
+		}
+
+		app.writeJSON(w, http.StatusCreated, envelope{"project": project})
+	default:
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	}
+}
+
+func (app *application) getUpdateDeleteProjectsHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		app.getProject(w, r)
+	case http.MethodPut:
+		app.updateProject(w, r)
+	case http.MethodDelete:
+		app.deleteProject(w, r)
+	default:
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	}
+}
+
+func (app *application) getProject(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(r.URL.Path[len("/v1/projects/"):], 10, 64)
+	if err != nil {
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	project, err := app.models.Projects.Get(id)
+	if err != nil {
+		app.logger.Printf("Error retrieving project with ID %d. Error: %s", id, err)
+		app.writeError(w, http.StatusNotFound)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, envelope{"project": project})
+}
+
+func (app *application) updateProject(w http.ResponseWriter, r *http.Request) {
+	if !app.isRequestAuthenticated(r) {
+		app.writeError(w, http.StatusForbidden)
+		return
+	}
+
+	id, err := strconv.ParseInt(r.URL.Path[len("/v1/projects/"):], 10, 64)
+	if err != nil {
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	project, err := app.models.Projects.Get(id)
+	if err != nil {
+		app.logger.Printf("Error retrieving project with ID %d for update. Error: %s", id, err)
+		app.writeError(w, http.StatusNotFound)
+		return
+	}
+
+	var input struct {
+		StartDate   *time.Time `json:"startDate"`
+		EndDate     *time.Time `json:"endDate"`
+		Title       *string    `json:"title"`
+		Description *string    `json:"description"`
+	}
+
+	err = app.readJSON(w, r, &input)
+	if err != nil {
+		app.logger.Printf("Error parsing project update payload. Error: %s", err)
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	if input.StartDate != nil {
+		project.StartDate = *input.StartDate
+	}
+
+	if input.EndDate != nil {
+		project.EndDate = input.EndDate
+	}
+
+	if input.Title != nil {
+		project.Title = *input.Title
+	}
+
+	if input.Description != nil {
+		project.Description = *input.Description
+	}
+
+	err = app.models.Projects.Update(project)
+	if err != nil {
+		app.logger.Printf("Error updating project with ID %d. Error: %s", id, err)
+		app.writeError(w, http.StatusInternalServerError)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, envelope{"project": project})
+}
+
+func (app *application) deleteProject(w http.ResponseWriter, r *http.Request) {
+	if !app.isRequestAuthenticated(r) {
+		app.writeError(w, http.StatusForbidden)
+		return
+	}
+
+	id, err := strconv.ParseInt(r.URL.Path[len("/v1/projects/"):], 10, 64)
+	if err != nil {
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	err = app.models.Projects.Delete(id)
+	if err != nil {
+		app.logger.Printf("Error deleting project with ID %d. Error: %s", id, err)
+		app.writeError(w, http.StatusNotFound)
+		return
+	}
+
+	app.writeJSON(w, http.StatusNoContent, envelope{"project": nil})
+}

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -16,5 +16,8 @@ func (app *application) routes() *http.ServeMux {
 	mux.HandleFunc("/v1/notes", app.getCreateNotesHandler)
 	mux.HandleFunc("/v1/notes/", app.getUpdateDeleteNotesHandler)
 
+	mux.HandleFunc("/v1/projects", app.getCreateProjectsHandler)
+	mux.HandleFunc("/v1/projects/", app.getUpdateDeleteProjectsHandler)
+
 	return mux
 }

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -10,6 +10,7 @@ type Models struct {
 	Roles     RoleModel
 	Companies CompanyModel
 	Notes     NoteModel
+	Projects  ProjectModel
 }
 
 func NewModels(db *sql.DB) Models {
@@ -17,6 +18,7 @@ func NewModels(db *sql.DB) Models {
 		Roles:     RoleModel{DB: db, Query: &querybuilder.QueryBuilder{DB: db}},
 		Companies: CompanyModel{DB: db, Query: &querybuilder.QueryBuilder{DB: db}},
 		Notes:     NoteModel{DB: db, Query: &querybuilder.QueryBuilder{DB: db}},
+		Projects:  ProjectModel{DB: db, Query: &querybuilder.QueryBuilder{DB: db}},
 	}
 
 }

--- a/internal/data/projects.go
+++ b/internal/data/projects.go
@@ -1,0 +1,278 @@
+package data
+
+import (
+	"database/sql"
+	"errors"
+	"time"
+
+	"api.etin.dev/pkg/querybuilder"
+)
+
+type Project struct {
+	ID          int64      `json:"id"`
+	CreatedAt   time.Time  `json:"-"`
+	UpdatedAt   time.Time  `json:"-"`
+	DeletedAt   *time.Time `json:"-"`
+	StartDate   time.Time  `json:"startDate"`
+	EndDate     *time.Time `json:"endDate,omitempty"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+}
+
+type ProjectModel struct {
+	DB    *sql.DB
+	Query *querybuilder.QueryBuilder
+}
+
+func (p ProjectModel) Insert(project *Project) error {
+	var endDate interface{}
+	if project.EndDate != nil {
+		endDate = *project.EndDate
+	}
+
+	values := querybuilder.Clauses{
+		{ColumnName: "startDate", Value: project.StartDate},
+		{ColumnName: "endDate", Value: endDate},
+		{ColumnName: "title", Value: project.Title},
+		{ColumnName: "description", Value: project.Description},
+	}
+
+	row, err := p.Query.SetBaseTable("projects").Insert(values).Returning(
+		"id",
+		"createdAt",
+		"updatedAt",
+		"deletedAt",
+		"startDate",
+		"endDate",
+		"title",
+		"description",
+	).QueryRow()
+	if err != nil {
+		return err
+	}
+
+	var deletedAt sql.NullTime
+	var savedEndDate sql.NullTime
+
+	err = row.Scan(
+		&project.ID,
+		&project.CreatedAt,
+		&project.UpdatedAt,
+		&deletedAt,
+		&project.StartDate,
+		&savedEndDate,
+		&project.Title,
+		&project.Description,
+	)
+	if err != nil {
+		return err
+	}
+
+	if deletedAt.Valid {
+		project.DeletedAt = &deletedAt.Time
+	} else {
+		project.DeletedAt = nil
+	}
+
+	if savedEndDate.Valid {
+		project.EndDate = &savedEndDate.Time
+	} else {
+		project.EndDate = nil
+	}
+
+	return nil
+}
+
+func (p ProjectModel) Get(projectID int64) (*Project, error) {
+	if projectID < 1 {
+		return nil, errors.New("record not found")
+	}
+
+	row, err := p.Query.SetBaseTable("projects").Select(
+		"id",
+		"createdAt",
+		"updatedAt",
+		"deletedAt",
+		"startDate",
+		"endDate",
+		"title",
+		"description",
+	).WhereEqual("deletedAt", nil).WhereEqual("id", projectID).QueryRow()
+	if err != nil {
+		return nil, err
+	}
+
+	var project Project
+	var deletedAt sql.NullTime
+	var endDate sql.NullTime
+
+	err = row.Scan(
+		&project.ID,
+		&project.CreatedAt,
+		&project.UpdatedAt,
+		&deletedAt,
+		&project.StartDate,
+		&endDate,
+		&project.Title,
+		&project.Description,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.New("record not found")
+		}
+		return nil, err
+	}
+
+	if deletedAt.Valid {
+		project.DeletedAt = &deletedAt.Time
+	}
+
+	if endDate.Valid {
+		project.EndDate = &endDate.Time
+	}
+
+	return &project, nil
+}
+
+func (p ProjectModel) Update(project *Project) error {
+	var endDate interface{}
+	if project.EndDate != nil {
+		endDate = *project.EndDate
+	}
+
+	values := querybuilder.Clauses{
+		{ColumnName: "startDate", Value: project.StartDate},
+		{ColumnName: "endDate", Value: endDate},
+		{ColumnName: "title", Value: project.Title},
+		{ColumnName: "description", Value: project.Description},
+		{ColumnName: "updatedAt", Value: time.Now()},
+	}
+
+	row, err := p.Query.SetBaseTable("projects").Update(values).WhereEqual("id", project.ID).WhereEqual("deletedAt", nil).Returning(
+		"id",
+		"createdAt",
+		"updatedAt",
+		"deletedAt",
+		"startDate",
+		"endDate",
+		"title",
+		"description",
+	).QueryRow()
+	if err != nil {
+		return err
+	}
+
+	var deletedAt sql.NullTime
+	var savedEndDate sql.NullTime
+
+	err = row.Scan(
+		&project.ID,
+		&project.CreatedAt,
+		&project.UpdatedAt,
+		&deletedAt,
+		&project.StartDate,
+		&savedEndDate,
+		&project.Title,
+		&project.Description,
+	)
+	if err != nil {
+		return err
+	}
+
+	if deletedAt.Valid {
+		project.DeletedAt = &deletedAt.Time
+	} else {
+		project.DeletedAt = nil
+	}
+
+	if savedEndDate.Valid {
+		project.EndDate = &savedEndDate.Time
+	} else {
+		project.EndDate = nil
+	}
+
+	return nil
+}
+
+func (p ProjectModel) Delete(projectID int64) error {
+	if projectID < 1 {
+		return errors.New("record not found")
+	}
+
+	values := querybuilder.Clauses{
+		{ColumnName: "updatedAt", Value: time.Now()},
+		{ColumnName: "deletedAt", Value: time.Now()},
+	}
+
+	results, err := p.Query.SetBaseTable("projects").Update(values).WhereEqual("id", projectID).WhereEqual("deletedAt", nil).Exec()
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := results.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return errors.New("record not found")
+	}
+
+	return nil
+}
+
+func (p ProjectModel) GetAll() ([]*Project, error) {
+	rows, err := p.Query.SetBaseTable("projects").Select(
+		"id",
+		"createdAt",
+		"updatedAt",
+		"deletedAt",
+		"startDate",
+		"endDate",
+		"title",
+		"description",
+	).WhereEqual("deletedAt", nil).OrderBy("startDate", "desc").Query()
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	projects := []*Project{}
+
+	for rows.Next() {
+		var project Project
+		var deletedAt sql.NullTime
+		var endDate sql.NullTime
+
+		err := rows.Scan(
+			&project.ID,
+			&project.CreatedAt,
+			&project.UpdatedAt,
+			&deletedAt,
+			&project.StartDate,
+			&endDate,
+			&project.Title,
+			&project.Description,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if deletedAt.Valid {
+			project.DeletedAt = &deletedAt.Time
+		}
+
+		if endDate.Valid {
+			project.EndDate = &endDate.Time
+		}
+
+		projects = append(projects, &project)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return projects, nil
+}


### PR DESCRIPTION
## Summary
- add a Project data model with CRUD operations in the data layer
- expose /v1/projects HTTP handlers for listing, creating, updating, and deleting projects
- register the projects handlers with the router so the new endpoints are available

## Testing
- go test ./pkg/querybuilder

------
https://chatgpt.com/codex/tasks/task_e_68e9d5f6c584832cb89c4e1eb5c8bb16