### PR TITLE
Add tag and tag item data models

### DIFF
--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -11,6 +11,8 @@ type Models struct {
 	Companies CompanyModel
 	Notes     NoteModel
 	Projects  ProjectModel
+	Tags      TagModel
+	TagItems  TagItemModel
 }
 
 func NewModels(db *sql.DB) Models {
@@ -19,6 +21,8 @@ func NewModels(db *sql.DB) Models {
 		Companies: CompanyModel{DB: db, Query: &querybuilder.QueryBuilder{DB: db}},
 		Notes:     NoteModel{DB: db, Query: &querybuilder.QueryBuilder{DB: db}},
 		Projects:  ProjectModel{DB: db, Query: &querybuilder.QueryBuilder{DB: db}},
+		Tags:      TagModel{DB: db, Query: &querybuilder.QueryBuilder{DB: db}},
+		TagItems:  TagItemModel{DB: db, Query: &querybuilder.QueryBuilder{DB: db}},
 	}
 
 }

--- a/internal/data/tag_items.go
+++ b/internal/data/tag_items.go
@@ -1,0 +1,173 @@
+package data
+
+import (
+	"database/sql"
+	"errors"
+
+	"api.etin.dev/pkg/querybuilder"
+)
+
+type ItemType string
+
+const (
+	ItemTypeNotes    ItemType = "notes"
+	ItemTypeRoles    ItemType = "roles"
+	ItemTypeProjects ItemType = "projects"
+)
+
+type TagItem struct {
+	ID       int64    `json:"id"`
+	TagID    int64    `json:"tagId"`
+	ItemID   int64    `json:"itemId"`
+	ItemType ItemType `json:"itemType"`
+}
+
+type TagItemModel struct {
+	DB    *sql.DB
+	Query *querybuilder.QueryBuilder
+}
+
+func (t TagItemModel) Insert(tagItem *TagItem) error {
+	if err := validateItemType(tagItem.ItemType); err != nil {
+		return err
+	}
+
+	values := querybuilder.Clauses{
+		{ColumnName: "tagId", Value: tagItem.TagID},
+		{ColumnName: "itemId", Value: tagItem.ItemID},
+		{ColumnName: "itemType", Value: string(tagItem.ItemType)},
+	}
+
+	row, err := t.Query.SetBaseTable("tagged_items").Insert(values).Returning("id").QueryRow()
+	if err != nil {
+		return err
+	}
+
+	return row.Scan(&tagItem.ID)
+}
+
+func (t TagItemModel) Delete(id int64) error {
+	if id < 1 {
+		return errors.New("record not found")
+	}
+
+	results, err := t.Query.SetBaseTable("tagged_items").Delete().WhereEqual("id", id).Exec()
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := results.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return errors.New("record not found")
+	}
+
+	return nil
+}
+
+func (t TagItemModel) RemoveTagFromItem(tagID, itemID int64, itemType ItemType) error {
+	if err := validateItemType(itemType); err != nil {
+		return err
+	}
+
+	results, err := t.Query.SetBaseTable("tagged_items").Delete().
+		WhereEqual("tagId", tagID).
+		WhereEqual("itemId", itemID).
+		WhereEqual("itemType", string(itemType)).
+		Exec()
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := results.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return errors.New("record not found")
+	}
+
+	return nil
+}
+
+func (t TagItemModel) GetTagsForItem(itemType ItemType, itemID int64) ([]*Tag, error) {
+	if err := validateItemType(itemType); err != nil {
+		return nil, err
+	}
+
+	rows, err := t.Query.SetBaseTable("tagged_items").Select(
+		"tags.id AS id",
+		"tags.createdAt AS createdAt",
+		"tags.updatedAt AS updatedAt",
+		"tags.deletedAt AS deletedAt",
+		"tags.name AS name",
+		"tags.slug AS slug",
+		"tags.icon AS icon",
+		"tags.theme AS theme",
+	).LeftJoin("tags", "tagId", "id").
+		WhereEqual("tagged_items.itemId", itemID).
+		WhereEqual("tagged_items.itemType", string(itemType)).
+		WhereEqual("tags.deletedAt", nil).
+		Query()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	tags := make([]*Tag, 0)
+
+	for rows.Next() {
+		tag := &Tag{}
+		var deletedAt sql.NullTime
+		var iconValue sql.NullString
+		var themeValue sql.NullString
+
+		if err := rows.Scan(
+			&tag.ID,
+			&tag.CreatedAt,
+			&tag.UpdatedAt,
+			&deletedAt,
+			&tag.Name,
+			&tag.Slug,
+			&iconValue,
+			&themeValue,
+		); err != nil {
+			return nil, err
+		}
+
+		if deletedAt.Valid {
+			tag.DeletedAt = &deletedAt.Time
+		}
+
+		if iconValue.Valid {
+			value := iconValue.String
+			tag.Icon = &value
+		}
+
+		if themeValue.Valid {
+			value := themeValue.String
+			tag.Theme = &value
+		}
+
+		tags = append(tags, tag)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return tags, nil
+}
+
+func validateItemType(itemType ItemType) error {
+	switch itemType {
+	case ItemTypeNotes, ItemTypeRoles, ItemTypeProjects:
+		return nil
+	default:
+		return errors.New("invalid item type")
+	}
+}

--- a/internal/data/tags.go
+++ b/internal/data/tags.go
@@ -1,0 +1,311 @@
+package data
+
+import (
+	"database/sql"
+	"errors"
+	"time"
+
+	"api.etin.dev/pkg/querybuilder"
+)
+
+type Tag struct {
+	ID        int64      `json:"id"`
+	CreatedAt time.Time  `json:"-"`
+	UpdatedAt time.Time  `json:"-"`
+	DeletedAt *time.Time `json:"-"`
+	Name      string     `json:"name"`
+	Slug      string     `json:"slug"`
+	Icon      *string    `json:"icon,omitempty"`
+	Theme     *string    `json:"theme,omitempty"`
+}
+
+type TagModel struct {
+	DB    *sql.DB
+	Query *querybuilder.QueryBuilder
+}
+
+func (t TagModel) Insert(tag *Tag) error {
+	var icon interface{}
+	if tag.Icon != nil {
+		icon = *tag.Icon
+	}
+
+	var theme interface{}
+	if tag.Theme != nil {
+		theme = *tag.Theme
+	}
+
+	values := querybuilder.Clauses{
+		{ColumnName: "name", Value: tag.Name},
+		{ColumnName: "slug", Value: tag.Slug},
+		{ColumnName: "icon", Value: icon},
+		{ColumnName: "theme", Value: theme},
+	}
+
+	row, err := t.Query.SetBaseTable("tags").Insert(values).Returning(
+		"id",
+		"createdAt",
+		"updatedAt",
+		"deletedAt",
+		"icon",
+		"theme",
+	).QueryRow()
+	if err != nil {
+		return err
+	}
+
+	var deletedAt sql.NullTime
+	var iconValue sql.NullString
+	var themeValue sql.NullString
+
+	if err := row.Scan(
+		&tag.ID,
+		&tag.CreatedAt,
+		&tag.UpdatedAt,
+		&deletedAt,
+		&iconValue,
+		&themeValue,
+	); err != nil {
+		return err
+	}
+
+	if deletedAt.Valid {
+		tag.DeletedAt = &deletedAt.Time
+	} else {
+		tag.DeletedAt = nil
+	}
+
+	if iconValue.Valid {
+		value := iconValue.String
+		tag.Icon = &value
+	} else {
+		tag.Icon = nil
+	}
+
+	if themeValue.Valid {
+		value := themeValue.String
+		tag.Theme = &value
+	} else {
+		tag.Theme = nil
+	}
+
+	return nil
+}
+
+func (t TagModel) Get(id int64) (*Tag, error) {
+	if id < 1 {
+		return nil, errors.New("record not found")
+	}
+
+	row, err := t.Query.SetBaseTable("tags").Select(
+		"id",
+		"createdAt",
+		"updatedAt",
+		"deletedAt",
+		"name",
+		"slug",
+		"icon",
+		"theme",
+	).WhereEqual("deletedAt", nil).WhereEqual("id", id).QueryRow()
+	if err != nil {
+		return nil, err
+	}
+
+	var tag Tag
+	var deletedAt sql.NullTime
+	var iconValue sql.NullString
+	var themeValue sql.NullString
+
+	if err := row.Scan(
+		&tag.ID,
+		&tag.CreatedAt,
+		&tag.UpdatedAt,
+		&deletedAt,
+		&tag.Name,
+		&tag.Slug,
+		&iconValue,
+		&themeValue,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.New("record not found")
+		}
+		return nil, err
+	}
+
+	if deletedAt.Valid {
+		tag.DeletedAt = &deletedAt.Time
+	}
+
+	if iconValue.Valid {
+		value := iconValue.String
+		tag.Icon = &value
+	}
+
+	if themeValue.Valid {
+		value := themeValue.String
+		tag.Theme = &value
+	}
+
+	return &tag, nil
+}
+
+func (t TagModel) Update(tag *Tag) error {
+	var icon interface{}
+	if tag.Icon != nil {
+		icon = *tag.Icon
+	}
+
+	var theme interface{}
+	if tag.Theme != nil {
+		theme = *tag.Theme
+	}
+
+	values := querybuilder.Clauses{
+		{ColumnName: "name", Value: tag.Name},
+		{ColumnName: "slug", Value: tag.Slug},
+		{ColumnName: "icon", Value: icon},
+		{ColumnName: "theme", Value: theme},
+		{ColumnName: "updatedAt", Value: time.Now()},
+	}
+
+	row, err := t.Query.SetBaseTable("tags").Update(values).WhereEqual("id", tag.ID).WhereEqual("deletedAt", nil).Returning(
+		"id",
+		"createdAt",
+		"updatedAt",
+		"deletedAt",
+		"name",
+		"slug",
+		"icon",
+		"theme",
+	).QueryRow()
+	if err != nil {
+		return err
+	}
+
+	var deletedAt sql.NullTime
+	var iconValue sql.NullString
+	var themeValue sql.NullString
+
+	if err := row.Scan(
+		&tag.ID,
+		&tag.CreatedAt,
+		&tag.UpdatedAt,
+		&deletedAt,
+		&tag.Name,
+		&tag.Slug,
+		&iconValue,
+		&themeValue,
+	); err != nil {
+		return err
+	}
+
+	if deletedAt.Valid {
+		tag.DeletedAt = &deletedAt.Time
+	} else {
+		tag.DeletedAt = nil
+	}
+
+	if iconValue.Valid {
+		value := iconValue.String
+		tag.Icon = &value
+	} else {
+		tag.Icon = nil
+	}
+
+	if themeValue.Valid {
+		value := themeValue.String
+		tag.Theme = &value
+	} else {
+		tag.Theme = nil
+	}
+
+	return nil
+}
+
+func (t TagModel) Delete(id int64) error {
+	if id < 1 {
+		return errors.New("record not found")
+	}
+
+	values := querybuilder.Clauses{
+		{ColumnName: "updatedAt", Value: time.Now()},
+		{ColumnName: "deletedAt", Value: time.Now()},
+	}
+
+	results, err := t.Query.SetBaseTable("tags").Update(values).WhereEqual("id", id).WhereEqual("deletedAt", nil).Exec()
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := results.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return errors.New("record not found")
+	}
+
+	return nil
+}
+
+func (t TagModel) GetAll() ([]*Tag, error) {
+	rows, err := t.Query.SetBaseTable("tags").Select(
+		"id",
+		"createdAt",
+		"updatedAt",
+		"deletedAt",
+		"name",
+		"slug",
+		"icon",
+		"theme",
+	).WhereEqual("deletedAt", nil).OrderBy("name", "asc").Query()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	tags := make([]*Tag, 0)
+
+	for rows.Next() {
+		tag := &Tag{}
+		var deletedAt sql.NullTime
+		var iconValue sql.NullString
+		var themeValue sql.NullString
+
+		if err := rows.Scan(
+			&tag.ID,
+			&tag.CreatedAt,
+			&tag.UpdatedAt,
+			&deletedAt,
+			&tag.Name,
+			&tag.Slug,
+			&iconValue,
+			&themeValue,
+		); err != nil {
+			return nil, err
+		}
+
+		if deletedAt.Valid {
+			tag.DeletedAt = &deletedAt.Time
+		}
+
+		if iconValue.Valid {
+			value := iconValue.String
+			tag.Icon = &value
+		}
+
+		if themeValue.Valid {
+			value := themeValue.String
+			tag.Theme = &value
+		}
+
+		tags = append(tags, tag)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return tags, nil
+}


### PR DESCRIPTION
## Summary
- add a Tag data model with CRUD helpers for working with the tags table
- introduce TagItem linking helpers to manage tagged_items relationships and fetch tags for an item
- expose the new models from the shared Models aggregate

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ea0b061224832c80f927692e5a460f