### PR TITLE
Add CRUD endpoints for item-note associations

### DIFF
--- a/cmd/api/handler_item_notes.go
+++ b/cmd/api/handler_item_notes.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"api.etin.dev/internal/data"
+)
+
+func (app *application) getCreateItemNotesHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		itemNotes, err := app.models.ItemNotes.GetAll()
+		if err != nil {
+			app.logger.Printf("Error retrieving item note associations: %s", err)
+			app.writeError(w, http.StatusInternalServerError)
+			return
+		}
+
+		app.writeJSON(w, http.StatusOK, envelope{"itemNotes": itemNotes})
+	case http.MethodPost:
+		if !app.isRequestAuthenticated(r) {
+			app.writeError(w, http.StatusForbidden)
+			return
+		}
+
+		var input struct {
+			NoteID   int64  `json:"noteId"`
+			ItemID   int64  `json:"itemId"`
+			ItemType string `json:"itemType"`
+		}
+
+		if err := app.readJSON(w, r, &input); err != nil {
+			app.logger.Printf("Could not parse item note association payload: %s", err)
+			app.writeError(w, http.StatusBadRequest)
+			return
+		}
+
+		if input.NoteID < 1 || input.ItemID < 1 || strings.TrimSpace(input.ItemType) == "" {
+			app.writeError(w, http.StatusBadRequest)
+			return
+		}
+
+		itemNote := &data.ItemNote{
+			NoteID:   input.NoteID,
+			ItemID:   input.ItemID,
+			ItemType: data.ItemType(strings.ToLower(input.ItemType)),
+		}
+
+		if err := app.models.ItemNotes.Insert(itemNote); err != nil {
+			if errors.Is(err, data.ErrInvalidItemType) {
+				app.writeError(w, http.StatusBadRequest)
+				return
+			}
+
+			app.logger.Printf("Could not create item note association: %s", err)
+			app.writeError(w, http.StatusBadRequest)
+			return
+		}
+
+		app.writeJSON(w, http.StatusCreated, envelope{"itemNote": itemNote})
+	default:
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	}
+}
+
+func (app *application) getUpdateDeleteItemNotesHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		app.getItemNote(w, r)
+	case http.MethodPut:
+		app.updateItemNote(w, r)
+	case http.MethodDelete:
+		app.deleteItemNote(w, r)
+	default:
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	}
+}
+
+func (app *application) getItemNote(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(r.URL.Path[len("/v1/item-notes/"):], 10, 64)
+	if err != nil {
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	itemNote, err := app.models.ItemNotes.Get(id)
+	if err != nil {
+		app.logger.Printf("Could not retrieve item note association %d: %s", id, err)
+		app.writeError(w, http.StatusNotFound)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, envelope{"itemNote": itemNote})
+}
+
+func (app *application) updateItemNote(w http.ResponseWriter, r *http.Request) {
+	if !app.isRequestAuthenticated(r) {
+		app.writeError(w, http.StatusForbidden)
+		return
+	}
+
+	id, err := strconv.ParseInt(r.URL.Path[len("/v1/item-notes/"):], 10, 64)
+	if err != nil {
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	itemNote, err := app.models.ItemNotes.Get(id)
+	if err != nil {
+		app.logger.Printf("Could not retrieve item note association %d: %s", id, err)
+		app.writeError(w, http.StatusNotFound)
+		return
+	}
+
+	var input struct {
+		NoteID   *int64  `json:"noteId"`
+		ItemID   *int64  `json:"itemId"`
+		ItemType *string `json:"itemType"`
+	}
+
+	if err := app.readJSON(w, r, &input); err != nil {
+		app.logger.Printf("Could not parse item note association update payload: %s", err)
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	if input.NoteID != nil {
+		itemNote.NoteID = *input.NoteID
+	}
+
+	if input.ItemID != nil {
+		itemNote.ItemID = *input.ItemID
+	}
+
+	if input.ItemType != nil {
+		itemNote.ItemType = data.ItemType(strings.ToLower(*input.ItemType))
+	}
+
+	if err := app.models.ItemNotes.Update(itemNote); err != nil {
+		if errors.Is(err, data.ErrInvalidItemType) {
+			app.writeError(w, http.StatusBadRequest)
+			return
+		}
+
+		app.logger.Printf("Could not update item note association %d: %s", id, err)
+		app.writeError(w, http.StatusInternalServerError)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, envelope{"itemNote": itemNote})
+}
+
+func (app *application) deleteItemNote(w http.ResponseWriter, r *http.Request) {
+	if !app.isRequestAuthenticated(r) {
+		app.writeError(w, http.StatusForbidden)
+		return
+	}
+
+	id, err := strconv.ParseInt(r.URL.Path[len("/v1/item-notes/"):], 10, 64)
+	if err != nil {
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	if err := app.models.ItemNotes.Delete(id); err != nil {
+		app.logger.Printf("Could not delete item note association %d: %s", id, err)
+		app.writeError(w, http.StatusNotFound)
+		return
+	}
+
+	app.writeJSON(w, http.StatusNoContent, envelope{"itemNote": nil})
+}
+
+func (app *application) getNotesForItemHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+
+	path := strings.TrimPrefix(r.URL.Path, "/v1/item-notes/items/")
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 {
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	itemID, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	itemType := data.ItemType(strings.ToLower(parts[0]))
+
+	notes, err := app.models.ItemNotes.GetNotesForItem(itemType, itemID)
+	if err != nil {
+		if errors.Is(err, data.ErrInvalidItemType) {
+			app.writeError(w, http.StatusBadRequest)
+			return
+		}
+
+		app.logger.Printf("Could not retrieve notes for %s item %d: %s", parts[0], itemID, err)
+		app.writeError(w, http.StatusInternalServerError)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, envelope{"notes": notes})
+}

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -15,6 +15,9 @@ func (app *application) routes() *http.ServeMux {
 
 	mux.HandleFunc("/v1/notes", app.getCreateNotesHandler)
 	mux.HandleFunc("/v1/notes/", app.getUpdateDeleteNotesHandler)
+	mux.HandleFunc("/v1/item-notes", app.getCreateItemNotesHandler)
+	mux.HandleFunc("/v1/item-notes/", app.getUpdateDeleteItemNotesHandler)
+	mux.HandleFunc("/v1/item-notes/items/", app.getNotesForItemHandler)
 
 	mux.HandleFunc("/v1/projects", app.getCreateProjectsHandler)
 	mux.HandleFunc("/v1/projects/", app.getUpdateDeleteProjectsHandler)

--- a/internal/data/tag_items.go
+++ b/internal/data/tag_items.go
@@ -7,6 +7,8 @@ import (
 	"api.etin.dev/pkg/querybuilder"
 )
 
+var ErrInvalidItemType = errors.New("invalid item type")
+
 type ItemType string
 
 const (
@@ -168,6 +170,6 @@ func validateItemType(itemType ItemType) error {
 	case ItemTypeNotes, ItemTypeRoles, ItemTypeProjects:
 		return nil
 	default:
-		return errors.New("invalid item type")
+		return ErrInvalidItemType
 	}
 }


### PR DESCRIPTION
## Summary
- add HTTP handlers for creating, updating, deleting, listing, and item-specific retrieval of note associations
- extend data models with CRUD support for item-note links and expose an invalid item type sentinel

## Testing
- go test ./internal/... ./pkg/...

------
https://chatgpt.com/codex/tasks/task_e_68ea6674905c832c8ac0bcd22034342a