### PR TITLE
Add generated OpenAPI specification endpoint

### DIFF
--- a/cmd/api/README.md
+++ b/cmd/api/README.md
@@ -6,5 +6,8 @@ This package wires together the HTTP API server. Key files include:
 - `routes.go`: declares the routing table and middleware stack.
 - `handlers.go` and `handler_*.go`: provide request handlers for domain entities such as companies and roles.
 - `helper.go`: shared utilities for responding to requests and managing dependencies.
+- `handler_swagger.go`: serves the generated OpenAPI specification at `/swagger`.
+
+The command generates the OpenAPI document on startup so the latest routes and schemas are always available from the `/swagger` endpoint.
 
 The command expects the database DSN and authorisation token to be supplied either as flags or via the environment variables `WEBSITE_DB_DSN` and `WEBSITE_AUTH_KEY`.

--- a/cmd/api/handler_swagger.go
+++ b/cmd/api/handler_swagger.go
@@ -1,0 +1,13 @@
+package main
+
+import "net/http"
+
+func (app *application) swaggerHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(app.swagger)
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"api.etin.dev/internal/data"
+	"api.etin.dev/pkg/openapi"
 	_ "github.com/lib/pq"
 )
 
@@ -23,9 +24,10 @@ type config struct {
 }
 
 type application struct {
-	config config
-	logger *log.Logger
-	models data.Models
+	config  config
+	logger  *log.Logger
+	models  data.Models
+	swagger []byte
 }
 
 func main() {
@@ -51,10 +53,16 @@ func main() {
 
 	logger.Printf("database connection pool established")
 
+	swaggerDoc, err := openapi.Build(version)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
 	app := &application{
-		config: cfg,
-		logger: logger,
-		models: data.NewModels(db),
+		config:  cfg,
+		logger:  logger,
+		models:  data.NewModels(db),
+		swagger: swaggerDoc,
 	}
 
 	addr := fmt.Sprintf(":%d", cfg.port)

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -5,6 +5,7 @@ import "net/http"
 func (app *application) routes() *http.ServeMux {
 	mux := http.NewServeMux()
 
+	mux.HandleFunc("/swagger", app.swaggerHandler)
 	mux.HandleFunc("/v1/healthcheck", app.healthcheck)
 
 	mux.HandleFunc("/v1/roles", app.getCreateRolesHandler)


### PR DESCRIPTION
## Summary
- add a Go-based OpenAPI document builder that enumerates schemas, security, and every public route
- generate the spec during startup and expose it from the new GET /swagger endpoint, documenting the addition

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ea887f2e44832caa72ce04327f38e2