### PR TITLE
Add admin login session authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,29 @@ psql -h localhost -U user -d website
 ```
 
 ### Running the server
-To run the server, you will need to build or run the `cmd/api` package. 
-It expects two environment variables (these can also be passed in as flags) for the database connection string and for 
-the authorisation key (this is a bit of a hack to secure the create and edit endpoints while I flesh out a 
-proper auth system)
+To run the server, you will need to build or run the `cmd/api` package.
+It expects environment variables (these can also be passed in as flags) for the database connection string
+and for the admin login credentials used to access write operations in the API.
 
 ```bash
-xport WEBSITE_DB_DSN='postgres://website:etin@localhost/website?sslmode=disable' && \
-export WEBSITE_AUTH_KEY='token-123' && \
+export WEBSITE_DB_DSN='postgres://website:etin@localhost/website?sslmode=disable' && \
+export WEBSITE_ADMIN_EMAIL='admin@example.com' && \
+export WEBSITE_ADMIN_PASSWORD='super-secret-password' && \
 go run ./cmd/api
 ```
+
+With the server running you can exchange the admin credentials for a bearer token by
+posting to the login endpoint:
+
+```bash
+curl -X POST http://localhost:4000/v1/admin/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@example.com","password":"super-secret-password"}'
+```
+
+The JSON response contains the bearer token and expiry timestamp. Supply this token in the
+`Authorization` header when calling any create, update or delete endpoints. To invalidate the
+token, call `POST /v1/admin/logout` with the same header.
 
 ### Tests
 Not a lot of tests yet, but hopefully changing soon. There are tests written for the `querybuilder` package. To run 

--- a/cmd/api/README.md
+++ b/cmd/api/README.md
@@ -10,4 +10,4 @@ This package wires together the HTTP API server. Key files include:
 
 The command generates the OpenAPI document on startup so the latest routes and schemas are always available from the `/swagger` endpoint.
 
-The command expects the database DSN and authorisation token to be supplied either as flags or via the environment variables `WEBSITE_DB_DSN` and `WEBSITE_AUTH_KEY`.
+The command expects the database DSN and admin credentials to be supplied either as flags or via the environment variables `WEBSITE_DB_DSN`, `WEBSITE_ADMIN_EMAIL`, and `WEBSITE_ADMIN_PASSWORD`.

--- a/cmd/api/auth.go
+++ b/cmd/api/auth.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+)
+
+type sessionManager struct {
+	mu       sync.RWMutex
+	sessions map[string]time.Time
+	ttl      time.Duration
+}
+
+func newSessionManager(ttl time.Duration) *sessionManager {
+	return &sessionManager{
+		sessions: make(map[string]time.Time),
+		ttl:      ttl,
+	}
+}
+
+func (sm *sessionManager) create() (string, time.Time, error) {
+	sm.cleanupExpired()
+
+	tokenBytes := make([]byte, 32)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		return "", time.Time{}, err
+	}
+
+	token := hex.EncodeToString(tokenBytes)
+	expiry := time.Now().Add(sm.ttl)
+
+	sm.mu.Lock()
+	sm.sessions[token] = expiry
+	sm.mu.Unlock()
+
+	return token, expiry, nil
+}
+
+func (sm *sessionManager) validate(token string) bool {
+	if token == "" {
+		return false
+	}
+
+	sm.mu.RLock()
+	expiry, ok := sm.sessions[token]
+	sm.mu.RUnlock()
+
+	if !ok {
+		return false
+	}
+
+	if time.Now().After(expiry) {
+		sm.mu.Lock()
+		delete(sm.sessions, token)
+		sm.mu.Unlock()
+		return false
+	}
+
+	return true
+}
+
+func (sm *sessionManager) revoke(token string) {
+	if token == "" {
+		return
+	}
+
+	sm.mu.Lock()
+	delete(sm.sessions, token)
+	sm.mu.Unlock()
+}
+
+func (sm *sessionManager) cleanupExpired() {
+	now := time.Now()
+
+	sm.mu.Lock()
+	for token, expiry := range sm.sessions {
+		if now.After(expiry) {
+			delete(sm.sessions, token)
+		}
+	}
+	sm.mu.Unlock()
+}
+
+func secureCompare(given, actual string) bool {
+	given = strings.TrimSpace(given)
+	actual = strings.TrimSpace(actual)
+	if len(given) == 0 || len(actual) == 0 {
+		return false
+	}
+	if len(given) != len(actual) {
+		return false
+	}
+	if subtle.ConstantTimeCompare([]byte(given), []byte(actual)) == 1 {
+		return true
+	}
+	return false
+}
+
+func parseBearerToken(header string) (string, error) {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return "", errors.New("missing authorization header")
+	}
+	const prefix = "Bearer "
+	if !strings.HasPrefix(header, prefix) {
+		return "", errors.New("authorization header is not a bearer token")
+	}
+	token := strings.TrimSpace(strings.TrimPrefix(header, prefix))
+	if token == "" {
+		return "", errors.New("authorization token missing")
+	}
+	return token, nil
+}

--- a/cmd/api/handler_auth.go
+++ b/cmd/api/handler_auth.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+func (app *application) adminLoginHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+
+	var input struct {
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}
+
+	err := app.readJSON(w, r, &input)
+	if err != nil {
+		app.logger.Printf("admin login: could not parse credentials: %v", err)
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	email := strings.TrimSpace(strings.ToLower(input.Email))
+	expectedEmail := strings.ToLower(app.config.adminEmail)
+
+	if email == "" || !secureCompare(email, expectedEmail) || !secureCompare(input.Password, app.config.adminPassword) {
+		app.writeError(w, http.StatusUnauthorized)
+		return
+	}
+
+	token, expiresAt, err := app.sessions.create()
+	if err != nil {
+		app.logger.Printf("admin login: could not create session: %v", err)
+		app.writeError(w, http.StatusInternalServerError)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, envelope{
+		"token":     token,
+		"expiresAt": expiresAt,
+	})
+}
+
+func (app *application) adminLogoutHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+
+	token, err := parseBearerToken(r.Header.Get("Authorization"))
+	if err != nil || !app.sessions.validate(token) {
+		app.writeError(w, http.StatusUnauthorized)
+		return
+	}
+
+	app.sessions.revoke(token)
+	app.writeJSON(w, http.StatusOK, envelope{"message": "logged out"})
+}

--- a/cmd/api/helper.go
+++ b/cmd/api/helper.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"strings"
 )
 
 type envelope map[string]any
@@ -48,8 +47,10 @@ func (app *application) readJSON(w http.ResponseWriter, r *http.Request, dst any
 }
 
 func (app *application) isRequestAuthenticated(r *http.Request) bool {
-	authHeader := strings.TrimSpace(r.Header.Get("Authorization"))
-	expected := "Bearer " + app.config.authKey
+	token, err := parseBearerToken(r.Header.Get("Authorization"))
+	if err != nil {
+		return false
+	}
 
-	return authHeader == expected
+	return app.sessions.validate(token)
 }

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -7,6 +7,8 @@ func (app *application) routes() *http.ServeMux {
 
 	mux.HandleFunc("/swagger", app.swaggerHandler)
 	mux.HandleFunc("/v1/healthcheck", app.healthcheck)
+	mux.HandleFunc("/v1/admin/login", app.adminLoginHandler)
+	mux.HandleFunc("/v1/admin/logout", app.adminLogoutHandler)
 
 	mux.HandleFunc("/v1/roles", app.getCreateRolesHandler)
 	mux.HandleFunc("/v1/roles/", app.getUpdateDeleteRolesHandler)


### PR DESCRIPTION
## Summary
- introduce a session manager with login/logout handlers to issue admin bearer tokens
- require admin credentials in configuration, update authenticated routes, and register new endpoints
- refresh documentation and OpenAPI schemas to describe the login workflow

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68eb5dd3fd30832c9539c381027899cf