### PR TITLE
Enable CORS for admin.etin.dev

### DIFF
--- a/cmd/api/middleware.go
+++ b/cmd/api/middleware.go
@@ -1,0 +1,27 @@
+package main
+
+import "net/http"
+
+const adminOrigin = "https://admin.etin.dev"
+
+func (app *application) enableCORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Vary", "Origin")
+		w.Header().Add("Vary", "Access-Control-Request-Method")
+		w.Header().Add("Vary", "Access-Control-Request-Headers")
+
+		origin := r.Header.Get("Origin")
+		if origin == adminOrigin {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -2,7 +2,7 @@ package main
 
 import "net/http"
 
-func (app *application) routes() *http.ServeMux {
+func (app *application) routes() http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/swagger", app.swaggerHandler)
@@ -25,5 +25,5 @@ func (app *application) routes() *http.ServeMux {
 	mux.HandleFunc("/v1/projects", app.getCreateProjectsHandler)
 	mux.HandleFunc("/v1/projects/", app.getUpdateDeleteProjectsHandler)
 
-	return mux
+	return app.enableCORS(mux)
 }


### PR DESCRIPTION
## Summary
- add a CORS middleware that allows requests from https://admin.etin.dev
- wrap the HTTP routing stack with the new middleware so all endpoints return the proper headers

## Testing
- go test ./... *(fails: hangs waiting for external dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68eb827411d4832ca00f0f5bd664024b