### PR TITLE
Set CORS allow origin to admin client

### DIFF
--- a/cmd/api/middleware.go
+++ b/cmd/api/middleware.go
@@ -10,17 +10,14 @@ func (app *application) enableCORS(next http.Handler) http.Handler {
 		w.Header().Add("Vary", "Access-Control-Request-Method")
 		w.Header().Add("Vary", "Access-Control-Request-Headers")
 
-		origin := r.Header.Get("Origin")
-		if origin == adminOrigin {
-			w.Header().Set("Access-Control-Allow-Origin", origin)
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+               w.Header().Set("Access-Control-Allow-Origin", adminOrigin)
+               w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+               w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
 
-			if r.Method == http.MethodOptions {
-				w.WriteHeader(http.StatusNoContent)
-				return
-			}
-		}
+               if r.Method == http.MethodOptions {
+                       w.WriteHeader(http.StatusNoContent)
+                       return
+               }
 
 		next.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
## Summary
- always set the CORS Access-Control-Allow-Origin header to the admin client origin
- keep the existing preflight handling in place for consistency

## Testing
- go test ./... *(hangs, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68eb86d16218832c848b5e19c87871c2