### PR TITLE
Fix configurable CORS handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,13 @@ and for the admin login credentials used to access write operations in the API.
 export WEBSITE_DB_DSN='postgres://website:etin@localhost/website?sslmode=disable' && \
 export WEBSITE_ADMIN_EMAIL='admin@example.com' && \
 export WEBSITE_ADMIN_PASSWORD='super-secret-password' && \
+export WEBSITE_CORS_TRUSTED_ORIGINS='http://localhost:3000 https://admin.example.com' && \
 go run ./cmd/api
 ```
+
+The optional `WEBSITE_CORS_TRUSTED_ORIGINS` environment variable (or the `-cors-trusted-origins` flag) accepts a space separated
+list of origins that should receive CORS headers. When unset, the API will automatically trust `https://etin.dev` and
+`https://admin.etin.dev`.
 
 With the server running you can exchange the admin credentials for a bearer token by
 posting to the login endpoint:

--- a/cmd/api/middleware.go
+++ b/cmd/api/middleware.go
@@ -2,23 +2,46 @@ package main
 
 import "net/http"
 
-const adminOrigin = "https://admin.etin.dev"
-
 func (app *application) enableCORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Vary", "Origin")
 		w.Header().Add("Vary", "Access-Control-Request-Method")
 		w.Header().Add("Vary", "Access-Control-Request-Headers")
 
-               w.Header().Set("Access-Control-Allow-Origin", adminOrigin)
-               w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-               w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+		if origin := r.Header.Get("Origin"); origin != "" {
+			if allowedOrigin, ok := app.getAllowedOrigin(origin); ok {
+				w.Header().Set("Access-Control-Allow-Origin", allowedOrigin)
+				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+				w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+				if allowedOrigin != "*" {
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
+				}
 
-               if r.Method == http.MethodOptions {
-                       w.WriteHeader(http.StatusNoContent)
-                       return
-               }
+				if r.Method == http.MethodOptions {
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+			}
+		}
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+func (app *application) getAllowedOrigin(origin string) (string, bool) {
+	for _, trustedOrigin := range app.config.cors.trustedOrigins {
+		if trustedOrigin == "*" {
+			return "*", true
+		}
+		if trustedOrigin == origin {
+			return origin, true
+		}
+	}
+
+	return "", false
 }


### PR DESCRIPTION
## Summary
- add configuration for trusted CORS origins with sensible defaults
- update the middleware to reflect the requesting origin and support credentials when allowed
- document the new environment variable and flag for configuring trusted origins

## Testing
- go test -timeout 30s api.etin.dev/pkg/querybuilder

------
https://chatgpt.com/codex/tasks/task_e_68eb88b2fd10832c95ee38f8836970e2