### PR TITLE
Normalize trusted CORS origins and add middleware test

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -56,6 +56,10 @@ func main() {
 		cfg.cors.trustedOrigins = []string{"https://admin.etin.dev", "https://etin.dev"}
 	}
 
+	for i, origin := range cfg.cors.trustedOrigins {
+		cfg.cors.trustedOrigins[i] = normalizeOrigin(origin)
+	}
+
 	if cfg.adminEmail == "" || cfg.adminPassword == "" {
 		logger.Fatal("Admin credentials must be provided")
 	}

--- a/cmd/api/middleware_test.go
+++ b/cmd/api/middleware_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+func TestGetAllowedOrigin_NormalizedMatch(t *testing.T) {
+	app := &application{}
+	app.config.cors.trustedOrigins = []string{
+		" https://ADMIN.ETIN.dev/ ",
+	}
+
+	for i, origin := range app.config.cors.trustedOrigins {
+		app.config.cors.trustedOrigins[i] = normalizeOrigin(origin)
+	}
+
+	allowedOrigin, ok := app.getAllowedOrigin("https://admin.etin.dev")
+	if !ok {
+		t.Fatalf("expected origin to be allowed")
+	}
+
+	if allowedOrigin != "https://admin.etin.dev" {
+		t.Fatalf("expected allowed origin to equal request origin; got %q", allowedOrigin)
+	}
+}


### PR DESCRIPTION
## Summary
- normalize trusted CORS origins during startup to remove trailing slashes and canonicalize scheme/host
- update the CORS middleware to compare normalized origins and return the request origin when matched
- add a focused unit test covering normalization logic for allowed origins

## Testing
- go test ./cmd/api


------
https://chatgpt.com/codex/tasks/task_e_68eb932448c4832c90fc66f70e1d6e35