### PR TITLE
Handle host-only CORS origins

### DIFF
--- a/cmd/api/middleware.go
+++ b/cmd/api/middleware.go
@@ -61,9 +61,38 @@ func normalizeOrigin(origin string) string {
 		return ""
 	}
 
+	if trimmed == "*" {
+		return "*"
+	}
+
+	if !strings.Contains(trimmed, "://") {
+		scheme := "https"
+		hostPort := trimmed
+
+		host := hostPort
+		if slash := strings.Index(host, "/"); slash != -1 {
+			host = host[:slash]
+		}
+		if colon := strings.Index(host, ":"); colon != -1 {
+			host = host[:colon]
+		}
+
+		lowerHost := strings.ToLower(host)
+		if lowerHost == "localhost" || strings.HasPrefix(lowerHost, "127.") || strings.HasPrefix(lowerHost, "0.0.0.0") || strings.HasPrefix(lowerHost, "[::1]") {
+			scheme = "http"
+		}
+
+		trimmed = scheme + "://" + hostPort
+	}
+
 	parsed, err := url.Parse(trimmed)
 	if err != nil {
 		return trimmed
+	}
+
+	if parsed.Host == "" && parsed.Path != "" {
+		parsed.Host = parsed.Path
+		parsed.Path = ""
 	}
 
 	if parsed.Scheme != "" {

--- a/cmd/api/middleware_test.go
+++ b/cmd/api/middleware_test.go
@@ -21,3 +21,42 @@ func TestGetAllowedOrigin_NormalizedMatch(t *testing.T) {
 		t.Fatalf("expected allowed origin to equal request origin; got %q", allowedOrigin)
 	}
 }
+
+func TestGetAllowedOrigin_HostOnlyConfig(t *testing.T) {
+	app := &application{}
+	app.config.cors.trustedOrigins = []string{
+		"admin.etin.dev",
+	}
+
+	for i, origin := range app.config.cors.trustedOrigins {
+		app.config.cors.trustedOrigins[i] = normalizeOrigin(origin)
+	}
+
+	allowedOrigin, ok := app.getAllowedOrigin("https://admin.etin.dev")
+	if !ok {
+		t.Fatalf("expected origin to be allowed")
+	}
+
+	if allowedOrigin != "https://admin.etin.dev" {
+		t.Fatalf("expected allowed origin to equal request origin; got %q", allowedOrigin)
+	}
+}
+
+func TestNormalizeOriginHostDefaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "https host", input: "admin.etin.dev", expected: "https://admin.etin.dev"},
+		{name: "localhost", input: "localhost:3000", expected: "http://localhost:3000"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeOrigin(tc.input); got != tc.expected {
+				t.Fatalf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- normalize configured CORS origins to include schemes, defaulting to https for domains and http for localhost/IP entries
- handle host-only entries by converting them to normalized URLs so they match incoming request origins
- add regression tests covering host-only configuration and normalization defaults

## Testing
- go test ./cmd/api -run TestGetAllowedOrigin -v

------
https://chatgpt.com/codex/tasks/task_e_68ebc3772054832ca37ffdca335ea408