### PR TITLE
Add endpoints for managing tags on items

### DIFF
--- a/cmd/api/handler_tag_items.go
+++ b/cmd/api/handler_tag_items.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"api.etin.dev/internal/data"
+)
+
+func (app *application) getCreateTagItemsHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		tagItems, err := app.models.TagItems.GetAll()
+		if err != nil {
+			app.logger.Printf("Error retrieving tag associations: %s", err)
+			app.writeError(w, http.StatusInternalServerError)
+			return
+		}
+
+		app.writeJSON(w, http.StatusOK, envelope{"taggedItems": tagItems})
+	case http.MethodPost:
+		if !app.isRequestAuthenticated(r) {
+			app.writeError(w, http.StatusForbidden)
+			return
+		}
+
+		var input struct {
+			TagID    int64  `json:"tagId"`
+			ItemID   int64  `json:"itemId"`
+			ItemType string `json:"itemType"`
+		}
+
+		if err := app.readJSON(w, r, &input); err != nil {
+			app.logger.Printf("Could not parse tag association payload: %s", err)
+			app.writeError(w, http.StatusBadRequest)
+			return
+		}
+
+		if input.TagID < 1 || input.ItemID < 1 || strings.TrimSpace(input.ItemType) == "" {
+			app.writeError(w, http.StatusBadRequest)
+			return
+		}
+
+		tagItem := &data.TagItem{
+			TagID:    input.TagID,
+			ItemID:   input.ItemID,
+			ItemType: data.ItemType(strings.ToLower(input.ItemType)),
+		}
+
+		if err := app.models.TagItems.Insert(tagItem); err != nil {
+			if errors.Is(err, data.ErrInvalidItemType) {
+				app.writeError(w, http.StatusBadRequest)
+				return
+			}
+
+			app.logger.Printf("Could not create tag association: %s", err)
+			app.writeError(w, http.StatusBadRequest)
+			return
+		}
+
+		app.writeJSON(w, http.StatusCreated, envelope{"taggedItem": tagItem})
+	default:
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	}
+}
+
+func (app *application) getUpdateDeleteTagItemsHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		app.getTagItem(w, r)
+	case http.MethodPut:
+		app.updateTagItem(w, r)
+	case http.MethodDelete:
+		app.deleteTagItem(w, r)
+	default:
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	}
+}
+
+func (app *application) getTagItem(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(r.URL.Path[len("/v1/tagged-items/"):], 10, 64)
+	if err != nil {
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	tagItem, err := app.models.TagItems.Get(id)
+	if err != nil {
+		app.logger.Printf("Could not retrieve tag association %d: %s", id, err)
+		app.writeError(w, http.StatusNotFound)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, envelope{"taggedItem": tagItem})
+}
+
+func (app *application) updateTagItem(w http.ResponseWriter, r *http.Request) {
+	if !app.isRequestAuthenticated(r) {
+		app.writeError(w, http.StatusForbidden)
+		return
+	}
+
+	id, err := strconv.ParseInt(r.URL.Path[len("/v1/tagged-items/"):], 10, 64)
+	if err != nil {
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	tagItem, err := app.models.TagItems.Get(id)
+	if err != nil {
+		app.logger.Printf("Could not retrieve tag association %d: %s", id, err)
+		app.writeError(w, http.StatusNotFound)
+		return
+	}
+
+	var input struct {
+		TagID    *int64  `json:"tagId"`
+		ItemID   *int64  `json:"itemId"`
+		ItemType *string `json:"itemType"`
+	}
+
+	if err := app.readJSON(w, r, &input); err != nil {
+		app.logger.Printf("Could not parse tag association update payload: %s", err)
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	if input.TagID != nil {
+		tagItem.TagID = *input.TagID
+	}
+
+	if input.ItemID != nil {
+		tagItem.ItemID = *input.ItemID
+	}
+
+	if input.ItemType != nil {
+		tagItem.ItemType = data.ItemType(strings.ToLower(*input.ItemType))
+	}
+
+	if err := app.models.TagItems.Update(tagItem); err != nil {
+		if errors.Is(err, data.ErrInvalidItemType) {
+			app.writeError(w, http.StatusBadRequest)
+			return
+		}
+
+		app.logger.Printf("Could not update tag association %d: %s", id, err)
+		app.writeError(w, http.StatusInternalServerError)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, envelope{"taggedItem": tagItem})
+}
+
+func (app *application) deleteTagItem(w http.ResponseWriter, r *http.Request) {
+	if !app.isRequestAuthenticated(r) {
+		app.writeError(w, http.StatusForbidden)
+		return
+	}
+
+	id, err := strconv.ParseInt(r.URL.Path[len("/v1/tagged-items/"):], 10, 64)
+	if err != nil {
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	if err := app.models.TagItems.Delete(id); err != nil {
+		app.logger.Printf("Could not delete tag association %d: %s", id, err)
+		app.writeError(w, http.StatusNotFound)
+		return
+	}
+
+	app.writeJSON(w, http.StatusNoContent, envelope{"taggedItem": nil})
+}
+
+func (app *application) getTagsForItemHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+
+	path := strings.TrimPrefix(r.URL.Path, "/v1/tagged-items/items/")
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 {
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	itemID, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		app.writeError(w, http.StatusBadRequest)
+		return
+	}
+
+	itemType := data.ItemType(strings.ToLower(parts[0]))
+
+	tags, err := app.models.TagItems.GetTagsForItem(itemType, itemID)
+	if err != nil {
+		if errors.Is(err, data.ErrInvalidItemType) {
+			app.writeError(w, http.StatusBadRequest)
+			return
+		}
+
+		app.logger.Printf("Could not retrieve tags for %s item %d: %s", parts[0], itemID, err)
+		app.writeError(w, http.StatusInternalServerError)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, envelope{"tags": tags})
+}

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -25,5 +25,9 @@ func (app *application) routes() http.Handler {
 	mux.HandleFunc("/v1/projects", app.getCreateProjectsHandler)
 	mux.HandleFunc("/v1/projects/", app.getUpdateDeleteProjectsHandler)
 
+	mux.HandleFunc("/v1/tagged-items", app.getCreateTagItemsHandler)
+	mux.HandleFunc("/v1/tagged-items/", app.getUpdateDeleteTagItemsHandler)
+	mux.HandleFunc("/v1/tagged-items/items/", app.getTagsForItemHandler)
+
 	return app.enableCORS(mux)
 }

--- a/pkg/openapi/spec.go
+++ b/pkg/openapi/spec.go
@@ -40,14 +40,14 @@ func Build(apiVersion string) ([]byte, error) {
 }
 
 func buildSecuritySchemes() map[string]any {
-        return map[string]any{
-                "bearerAuth": map[string]any{
-                        "type":         "http",
-                        "scheme":       "bearer",
-                        "bearerFormat": "opaque token",
-                        "description":  "Bearer token issued by the admin login endpoint.",
-                },
-        }
+	return map[string]any{
+		"bearerAuth": map[string]any{
+			"type":         "http",
+			"scheme":       "bearer",
+			"bearerFormat": "opaque token",
+			"description":  "Bearer token issued by the admin login endpoint.",
+		},
+	}
 }
 
 func buildSchemas() map[string]any {
@@ -77,31 +77,31 @@ func buildSchemas() map[string]any {
 		return map[string]any{"$ref": "#/components/schemas/" + name}
 	}
 
-        return map[string]any{
-                "AdminLoginRequest": map[string]any{
-                        "type":     "object",
-                        "required": []string{"email", "password"},
-                        "properties": map[string]any{
-                                "email":    stringSchema("Admin email address."),
-                                "password": stringSchema("Admin password."),
-                        },
-                },
-                "AdminLoginResponse": map[string]any{
-                        "type":     "object",
-                        "required": []string{"token", "expiresAt"},
-                        "properties": map[string]any{
-                                "token":     stringSchema("Bearer token used to authenticate administrative requests."),
-                                "expiresAt": dateTimeSchema("Timestamp when the session token expires."),
-                        },
-                },
-                "AdminLogoutResponse": map[string]any{
-                        "type": "object",
-                        "properties": map[string]any{
-                                "message": stringSchema("Confirmation message."),
-                        },
-                },
-                "HealthcheckResponse": map[string]any{
-                        "type":     "object",
+	return map[string]any{
+		"AdminLoginRequest": map[string]any{
+			"type":     "object",
+			"required": []string{"email", "password"},
+			"properties": map[string]any{
+				"email":    stringSchema("Admin email address."),
+				"password": stringSchema("Admin password."),
+			},
+		},
+		"AdminLoginResponse": map[string]any{
+			"type":     "object",
+			"required": []string{"token", "expiresAt"},
+			"properties": map[string]any{
+				"token":     stringSchema("Bearer token used to authenticate administrative requests."),
+				"expiresAt": dateTimeSchema("Timestamp when the session token expires."),
+			},
+		},
+		"AdminLogoutResponse": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"message": stringSchema("Confirmation message."),
+			},
+		},
+		"HealthcheckResponse": map[string]any{
+			"type":     "object",
 			"required": []string{"status", "environment", "version"},
 			"properties": map[string]any{
 				"status":      stringSchema("Service availability status."),
@@ -262,6 +262,26 @@ func buildSchemas() map[string]any {
 				},
 			},
 		},
+		"Tag": map[string]any{
+			"type":     "object",
+			"required": []string{"id", "name", "slug"},
+			"properties": map[string]any{
+				"id":    int64Schema("Database identifier."),
+				"name":  stringSchema("Tag display name."),
+				"slug":  stringSchema("URL slug for the tag."),
+				"icon":  stringSchema("Optional emoji or icon for the tag."),
+				"theme": stringSchema("Optional theme identifier for the tag."),
+			},
+		},
+		"TagsResponse": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"tags": map[string]any{
+					"type":  "array",
+					"items": ref("Tag"),
+				},
+			},
+		},
 		"Note": map[string]any{
 			"type":     "object",
 			"required": []string{"id", "title", "subtitle", "body"},
@@ -361,6 +381,60 @@ func buildSchemas() map[string]any {
 				},
 			},
 		},
+		"TagItem": map[string]any{
+			"type":     "object",
+			"required": []string{"id", "tagId", "itemId", "itemType"},
+			"properties": map[string]any{
+				"id":     int64Schema("Database identifier."),
+				"tagId":  int64Schema("Linked tag identifier."),
+				"itemId": int64Schema("Linked item identifier."),
+				"itemType": map[string]any{
+					"type":        "string",
+					"description": "Type of item linked to the tag.",
+					"enum":        []string{"notes", "roles", "projects"},
+				},
+			},
+		},
+		"CreateTagItemRequest": map[string]any{
+			"type":     "object",
+			"required": []string{"tagId", "itemId", "itemType"},
+			"properties": map[string]any{
+				"tagId":  int64Schema("Linked tag identifier."),
+				"itemId": int64Schema("Linked item identifier."),
+				"itemType": map[string]any{
+					"type":        "string",
+					"description": "Type of item linked to the tag.",
+					"enum":        []string{"notes", "roles", "projects"},
+				},
+			},
+		},
+		"UpdateTagItemRequest": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"tagId":  int64Schema("Linked tag identifier."),
+				"itemId": int64Schema("Linked item identifier."),
+				"itemType": map[string]any{
+					"type":        "string",
+					"description": "Type of item linked to the tag.",
+					"enum":        []string{"notes", "roles", "projects"},
+				},
+			},
+		},
+		"TagItemResponse": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"taggedItem": ref("TagItem"),
+			},
+		},
+		"TagItemsResponse": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"taggedItems": map[string]any{
+					"type":  "array",
+					"items": ref("TagItem"),
+				},
+			},
+		},
 	}
 }
 
@@ -403,78 +477,78 @@ func buildPaths() map[string]any {
 		"name":        "itemType",
 		"in":          "path",
 		"required":    true,
-		"description": "Type of item to fetch notes for.",
+		"description": "Type of item to fetch related records for.",
 		"schema": map[string]any{
 			"type": "string",
 			"enum": []string{"notes", "roles", "projects"},
 		},
 	}
 
-	itemIdParam := intPathParam("itemId", "Identifier of the item to fetch notes for.")
+	itemIdParam := intPathParam("itemId", "Identifier of the item to fetch related records for.")
 
-        paths := map[string]any{
-                "/v1/healthcheck": map[string]any{
-                        "get": map[string]any{
-                                "operationId": "getHealthcheck",
-                                "summary":     "Check service health",
-                                "tags":        []string{"Health"},
-                                "responses": map[string]any{
-                                        "200": jsonResponse("Service is available.", "HealthcheckResponse"),
-                                },
-                        },
-                },
-                "/swagger": map[string]any{
-                        "get": map[string]any{
-                                "operationId": "getSwaggerDocument",
-                                "summary":     "Retrieve the OpenAPI specification",
-                                "tags":        []string{"Documentation"},
-                                "responses": map[string]any{
-                                        "200": map[string]any{
-                                                "description": "OpenAPI document for the API.",
-                                                "content": map[string]any{
-                                                        "application/json": map[string]any{
-                                                                "schema": map[string]any{"type": "object"},
-                                                        },
-                                                },
-                                        },
-                                },
-                        },
-                },
-                "/v1/admin/login": map[string]any{
-                        "post": map[string]any{
-                                "operationId": "adminLogin",
-                                "summary":     "Create an admin session token",
-                                "tags":        []string{"Administration"},
-                                "requestBody": map[string]any{
-                                        "required": true,
-                                        "content": map[string]any{
-                                                "application/json": map[string]any{
-                                                        "schema": ref("AdminLoginRequest"),
-                                                },
-                                        },
-                                },
-                                "responses": map[string]any{
-                                        "200": jsonResponse("Admin session created.", "AdminLoginResponse"),
-                                        "400": noContent("Invalid credentials payload."),
-                                        "401": noContent("Invalid admin credentials."),
-                                },
-                        },
-                },
-                "/v1/admin/logout": map[string]any{
-                        "post": map[string]any{
-                                "operationId": "adminLogout",
-                                "summary":     "Invalidate the current admin session token",
-                                "tags":        []string{"Administration"},
-                                "security":   bearerSecurity,
-                                "responses": map[string]any{
-                                        "200": jsonResponse("Admin session revoked.", "AdminLogoutResponse"),
-                                        "401": noContent("Missing or invalid bearer token."),
-                                },
-                        },
-                },
-                "/v1/roles": map[string]any{
-                        "get": map[string]any{
-                                "operationId": "listRoles",
+	paths := map[string]any{
+		"/v1/healthcheck": map[string]any{
+			"get": map[string]any{
+				"operationId": "getHealthcheck",
+				"summary":     "Check service health",
+				"tags":        []string{"Health"},
+				"responses": map[string]any{
+					"200": jsonResponse("Service is available.", "HealthcheckResponse"),
+				},
+			},
+		},
+		"/swagger": map[string]any{
+			"get": map[string]any{
+				"operationId": "getSwaggerDocument",
+				"summary":     "Retrieve the OpenAPI specification",
+				"tags":        []string{"Documentation"},
+				"responses": map[string]any{
+					"200": map[string]any{
+						"description": "OpenAPI document for the API.",
+						"content": map[string]any{
+							"application/json": map[string]any{
+								"schema": map[string]any{"type": "object"},
+							},
+						},
+					},
+				},
+			},
+		},
+		"/v1/admin/login": map[string]any{
+			"post": map[string]any{
+				"operationId": "adminLogin",
+				"summary":     "Create an admin session token",
+				"tags":        []string{"Administration"},
+				"requestBody": map[string]any{
+					"required": true,
+					"content": map[string]any{
+						"application/json": map[string]any{
+							"schema": ref("AdminLoginRequest"),
+						},
+					},
+				},
+				"responses": map[string]any{
+					"200": jsonResponse("Admin session created.", "AdminLoginResponse"),
+					"400": noContent("Invalid credentials payload."),
+					"401": noContent("Invalid admin credentials."),
+				},
+			},
+		},
+		"/v1/admin/logout": map[string]any{
+			"post": map[string]any{
+				"operationId": "adminLogout",
+				"summary":     "Invalidate the current admin session token",
+				"tags":        []string{"Administration"},
+				"security":    bearerSecurity,
+				"responses": map[string]any{
+					"200": jsonResponse("Admin session revoked.", "AdminLogoutResponse"),
+					"401": noContent("Missing or invalid bearer token."),
+				},
+			},
+		},
+		"/v1/roles": map[string]any{
+			"get": map[string]any{
+				"operationId": "listRoles",
 				"summary":     "List roles",
 				"tags":        []string{"Roles"},
 				"responses": map[string]any{
@@ -871,6 +945,97 @@ func buildPaths() map[string]any {
 					"200": jsonResponse("Notes retrieved.", "NotesResponse"),
 					"400": noContent("Invalid item type or identifier."),
 					"500": noContent("Server error retrieving notes for the item."),
+				},
+			},
+		},
+		"/v1/tagged-items": map[string]any{
+			"get": map[string]any{
+				"operationId": "listTagItems",
+				"summary":     "List tag associations",
+				"tags":        []string{"Tag Items"},
+				"responses": map[string]any{
+					"200": jsonResponse("Tag associations retrieved.", "TagItemsResponse"),
+					"500": noContent("Server error retrieving tag associations."),
+				},
+			},
+			"post": map[string]any{
+				"operationId": "createTagItem",
+				"summary":     "Create a tag association",
+				"tags":        []string{"Tag Items"},
+				"security":    bearerSecurity,
+				"requestBody": map[string]any{
+					"required": true,
+					"content": map[string]any{
+						"application/json": map[string]any{
+							"schema": ref("CreateTagItemRequest"),
+						},
+					},
+				},
+				"responses": map[string]any{
+					"201": jsonResponse("Tag association created.", "TagItemResponse"),
+					"400": noContent("Invalid payload."),
+					"403": noContent("Missing or invalid bearer token."),
+				},
+			},
+		},
+		"/v1/tagged-items/{taggedItemId}": map[string]any{
+			"get": map[string]any{
+				"operationId": "getTagItem",
+				"summary":     "Retrieve a tag association",
+				"tags":        []string{"Tag Items"},
+				"parameters":  []map[string]any{intPathParam("taggedItemId", "Identifier of the tag association.")},
+				"responses": map[string]any{
+					"200": jsonResponse("Tag association retrieved.", "TagItemResponse"),
+					"400": noContent("Invalid tag association identifier."),
+					"404": noContent("Tag association not found."),
+				},
+			},
+			"put": map[string]any{
+				"operationId": "updateTagItem",
+				"summary":     "Update a tag association",
+				"tags":        []string{"Tag Items"},
+				"security":    bearerSecurity,
+				"parameters":  []map[string]any{intPathParam("taggedItemId", "Identifier of the tag association.")},
+				"requestBody": map[string]any{
+					"required": true,
+					"content": map[string]any{
+						"application/json": map[string]any{
+							"schema": ref("UpdateTagItemRequest"),
+						},
+					},
+				},
+				"responses": map[string]any{
+					"200": jsonResponse("Tag association updated.", "TagItemResponse"),
+					"400": noContent("Invalid payload."),
+					"403": noContent("Missing or invalid bearer token."),
+					"404": noContent("Tag association not found."),
+					"500": noContent("Server error updating tag association."),
+				},
+			},
+			"delete": map[string]any{
+				"operationId": "deleteTagItem",
+				"summary":     "Delete a tag association",
+				"tags":        []string{"Tag Items"},
+				"security":    bearerSecurity,
+				"parameters":  []map[string]any{intPathParam("taggedItemId", "Identifier of the tag association.")},
+				"responses": map[string]any{
+					"204": noContent("Tag association deleted."),
+					"400": noContent("Invalid tag association identifier."),
+					"403": noContent("Missing or invalid bearer token."),
+					"404": noContent("Tag association not found."),
+				},
+			},
+		},
+		"/v1/tagged-items/items/{itemType}/{itemId}": map[string]any{
+			"get": map[string]any{
+				"operationId": "listTagsForItem",
+				"summary":     "List tags associated with an item",
+				"tags":        []string{"Tag Items"},
+				"parameters":  []map[string]any{itemTypeParam, itemIdParam},
+				"responses": map[string]any{
+					"200": jsonResponse("Tags retrieved.", "TagsResponse"),
+					"400": noContent("Invalid item type or identifier."),
+					"500": noContent("Server error retrieving tags for the item."),
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- add HTTP handlers and routes for creating, updating, deleting, and listing tag associations
- extend the tag item data model with helpers for fetching individual associations and tags per item
- document the new schemas and paths in the OpenAPI specification

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68eddf46744c832cb96d656bacfb1afc