### PR TITLE
Add authenticated asset upload endpoint

### DIFF
--- a/cmd/api/README.md
+++ b/cmd/api/README.md
@@ -11,3 +11,20 @@ This package wires together the HTTP API server. Key files include:
 The command generates the OpenAPI document on startup so the latest routes and schemas are always available from the `/swagger` endpoint.
 
 The command expects the database DSN and admin credentials to be supplied either as flags or via the environment variables `WEBSITE_DB_DSN`, `WEBSITE_ADMIN_EMAIL`, and `WEBSITE_ADMIN_PASSWORD`.
+
+## Asset uploads
+
+Authenticated administrators can push files to Cloudinary through the `/v1/assets` endpoint. Send a
+`multipart/form-data` request containing a single `file` part; payloads are limited to 10 MiB. The
+API streams the file to Cloudinary, persists the returned metadata, and responds with the database
+record containing the secure delivery URL.
+
+```bash
+curl -X POST http://localhost:4000/v1/assets \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -F "file=@./banner.png"
+```
+
+Requests missing the `file` part or exceeding the size limit are rejected with `400` or `413`
+responses. Upload failures from Cloudinary surface as `502`, and database persistence issues return
+`500`.

--- a/cmd/api/handler_assets.go
+++ b/cmd/api/handler_assets.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"errors"
+	"mime/multipart"
+	"net/http"
+
+	"api.etin.dev/internal/assets"
+	"api.etin.dev/internal/data"
+)
+
+const maxAssetUploadBytes = 10 << 20 // 10 MiB
+
+type assetSaver interface {
+	Insert(*data.Asset) error
+}
+
+func (app *application) getCreateAssetsHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		{
+			if !app.isRequestAuthenticated(r) {
+				app.writeError(w, http.StatusForbidden)
+				return
+			}
+
+			r.Body = http.MaxBytesReader(w, r.Body, maxAssetUploadBytes)
+			if err := r.ParseMultipartForm(maxAssetUploadBytes); err != nil {
+				if app.logger != nil {
+					app.logger.Printf("parse multipart form: %v", err)
+				}
+				var maxBytesErr *http.MaxBytesError
+				if errors.As(err, &maxBytesErr) {
+					app.writeError(w, http.StatusRequestEntityTooLarge)
+					return
+				}
+				if errors.Is(err, http.ErrNotMultipart) {
+					app.writeError(w, http.StatusBadRequest)
+					return
+				}
+
+				if errors.Is(err, multipart.ErrMessageTooLarge) {
+					app.writeError(w, http.StatusRequestEntityTooLarge)
+					return
+				}
+
+				app.writeError(w, http.StatusBadRequest)
+				return
+			}
+			defer func() {
+				if r.MultipartForm != nil {
+					r.MultipartForm.RemoveAll()
+				}
+			}()
+
+			file, _, err := r.FormFile("file")
+			if err != nil {
+				if app.logger != nil {
+					app.logger.Printf("read file part: %v", err)
+				}
+				if errors.Is(err, http.ErrMissingFile) {
+					app.writeError(w, http.StatusBadRequest)
+					return
+				}
+
+				app.writeError(w, http.StatusBadRequest)
+				return
+			}
+			defer file.Close()
+
+			result, err := app.assets.Upload(r.Context(), file, assets.UploadOptions{})
+			if err != nil {
+				if app.logger != nil {
+					app.logger.Printf("upload asset: %v", err)
+				}
+				app.writeError(w, http.StatusBadGateway)
+				return
+			}
+
+			asset := &data.Asset{
+				URL:          result.URL,
+				SecureURL:    result.SecureURL,
+				PublicID:     result.PublicID,
+				Format:       result.Format,
+				ResourceType: result.ResourceType,
+				Bytes:        result.Bytes,
+				Width:        result.Width,
+				Height:       result.Height,
+			}
+
+			if err := app.assetModel.Insert(asset); err != nil {
+				if app.logger != nil {
+					app.logger.Printf("persist asset: %v", err)
+				}
+				app.writeError(w, http.StatusInternalServerError)
+				return
+			}
+
+			app.writeJSON(w, http.StatusCreated, envelope{"asset": asset})
+			return
+		}
+	default:
+		{
+			w.Header().Set("Allow", http.MethodPost)
+			app.writeError(w, http.StatusMethodNotAllowed)
+			return
+		}
+	}
+}

--- a/cmd/api/handler_assets_test.go
+++ b/cmd/api/handler_assets_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"api.etin.dev/internal/assets"
+	"api.etin.dev/internal/data"
+)
+
+type stubUploader struct {
+	result *assets.UploadResult
+	err    error
+}
+
+func (s *stubUploader) Upload(_ context.Context, file io.Reader, _ assets.UploadOptions) (*assets.UploadResult, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+
+	// Drain the reader to mimic Cloudinary consumption and ensure callers can stream.
+	io.Copy(io.Discard, file)
+
+	if s.result == nil {
+		return &assets.UploadResult{}, nil
+	}
+
+	clone := *s.result
+	return &clone, nil
+}
+
+type stubAssetSaver struct {
+	saved  []*data.Asset
+	err    error
+	nextID int64
+}
+
+func (s *stubAssetSaver) Insert(asset *data.Asset) error {
+	if s.err != nil {
+		return s.err
+	}
+
+	s.nextID++
+	asset.ID = s.nextID
+
+	copy := *asset
+	s.saved = append(s.saved, &copy)
+	return nil
+}
+
+func newAuthenticatedApp(t *testing.T, uploader assets.Uploader, saver assetSaver) (*application, string) {
+	t.Helper()
+
+	sm := newSessionManager(time.Hour)
+	token, expiry, err := sm.create()
+	if err != nil {
+		t.Fatalf("failed to seed session token: %v", err)
+	}
+
+	sm.sessions[token] = expiry.Add(time.Hour)
+
+	app := &application{
+		logger:     log.New(io.Discard, "", 0),
+		assets:     uploader,
+		assetModel: saver,
+		sessions:   sm,
+	}
+
+	return app, token
+}
+
+func createMultipartRequest(t *testing.T, token string, payload []byte) (*http.Request, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	if payload != nil {
+		part, err := writer.CreateFormFile("file", "test.bin")
+		if err != nil {
+			t.Fatalf("create form file: %v", err)
+		}
+		if _, err := part.Write(payload); err != nil {
+			t.Fatalf("write payload: %v", err)
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/assets", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rr := httptest.NewRecorder()
+	return req, rr
+}
+
+func TestGetCreateAssetsHandler_Success(t *testing.T) {
+	uploader := &stubUploader{result: &assets.UploadResult{
+		AssetID:      "asset123",
+		PublicID:     "public123",
+		Format:       "png",
+		ResourceType: "image",
+		URL:          "http://example.com/resource.png",
+		SecureURL:    "https://example.com/resource.png",
+		Version:      1,
+		Bytes:        512,
+		Width:        10,
+		Height:       10,
+	}}
+
+	saver := &stubAssetSaver{}
+
+	app, token := newAuthenticatedApp(t, uploader, saver)
+
+	req, rr := createMultipartRequest(t, token, []byte("hello world"))
+
+	app.getCreateAssetsHandler(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status %d; got %d", http.StatusCreated, rr.Code)
+	}
+
+	if len(saver.saved) != 1 {
+		t.Fatalf("expected asset to be saved")
+	}
+
+	var payload struct {
+		Asset data.Asset `json:"asset"`
+	}
+
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if payload.Asset.ID == 0 {
+		t.Fatalf("expected asset ID to be populated")
+	}
+
+	if payload.Asset.SecureURL != uploader.result.SecureURL {
+		t.Fatalf("expected secure URL to match upload result")
+	}
+}
+
+func TestGetCreateAssetsHandler_MissingFile(t *testing.T) {
+	uploader := &stubUploader{result: &assets.UploadResult{}}
+	saver := &stubAssetSaver{}
+	app, token := newAuthenticatedApp(t, uploader, saver)
+
+	req, rr := createMultipartRequest(t, token, nil)
+
+	app.getCreateAssetsHandler(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d; got %d", http.StatusBadRequest, rr.Code)
+	}
+
+	if len(saver.saved) != 0 {
+		t.Fatalf("expected no assets to be saved")
+	}
+}
+
+func TestGetCreateAssetsHandler_FileTooLarge(t *testing.T) {
+	uploader := &stubUploader{result: &assets.UploadResult{}}
+	saver := &stubAssetSaver{}
+	app, token := newAuthenticatedApp(t, uploader, saver)
+
+	largePayload := bytes.Repeat([]byte("a"), int(maxAssetUploadBytes)+1)
+
+	req, rr := createMultipartRequest(t, token, largePayload)
+
+	app.getCreateAssetsHandler(rr, req)
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected status %d; got %d", http.StatusRequestEntityTooLarge, rr.Code)
+	}
+
+	if len(saver.saved) != 0 {
+		t.Fatalf("expected no assets to be saved")
+	}
+}
+
+func TestGetCreateAssetsHandler_UploadFailure(t *testing.T) {
+	uploader := &stubUploader{err: errors.New("upload failed")}
+	saver := &stubAssetSaver{}
+	app, token := newAuthenticatedApp(t, uploader, saver)
+
+	req, rr := createMultipartRequest(t, token, []byte("hello world"))
+
+	app.getCreateAssetsHandler(rr, req)
+
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("expected status %d; got %d", http.StatusBadGateway, rr.Code)
+	}
+
+	if len(saver.saved) != 0 {
+		t.Fatalf("expected no assets to be saved")
+	}
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -36,12 +36,13 @@ type config struct {
 }
 
 type application struct {
-	config   config
-	logger   *log.Logger
-	models   data.Models
-	assets   assets.Uploader
-	swagger  []byte
-	sessions *sessionManager
+	config     config
+	logger     *log.Logger
+	models     data.Models
+	assetModel assetSaver
+	assets     assets.Uploader
+	swagger    []byte
+	sessions   *sessionManager
 }
 
 func main() {
@@ -111,13 +112,16 @@ func main() {
 		logger.Fatal(err)
 	}
 
+	models := data.NewModels(db)
+
 	app := &application{
-		config:   cfg,
-		logger:   logger,
-		models:   data.NewModels(db),
-		assets:   uploader,
-		swagger:  swaggerDoc,
-		sessions: newSessionManager(24 * time.Hour),
+		config:     cfg,
+		logger:     logger,
+		models:     models,
+		assetModel: models.Assets,
+		assets:     uploader,
+		swagger:    swaggerDoc,
+		sessions:   newSessionManager(24 * time.Hour),
 	}
 
 	addr := fmt.Sprintf(":%d", cfg.port)

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -6,11 +6,13 @@ func (app *application) routes() http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/swagger", app.swaggerHandler)
-	mux.HandleFunc("/v1/healthcheck", app.healthcheck)
-	mux.HandleFunc("/v1/admin/login", app.adminLoginHandler)
-	mux.HandleFunc("/v1/admin/logout", app.adminLogoutHandler)
+        mux.HandleFunc("/v1/healthcheck", app.healthcheck)
+        mux.HandleFunc("/v1/admin/login", app.adminLoginHandler)
+        mux.HandleFunc("/v1/admin/logout", app.adminLogoutHandler)
 
-	mux.HandleFunc("/v1/roles", app.getCreateRolesHandler)
+        mux.HandleFunc("/v1/assets", app.getCreateAssetsHandler)
+
+        mux.HandleFunc("/v1/roles", app.getCreateRolesHandler)
 	mux.HandleFunc("/v1/roles/", app.getUpdateDeleteRolesHandler)
 
 	mux.HandleFunc("/v1/companies", app.getCreateCompaniesHandler)

--- a/pkg/openapi/spec.go
+++ b/pkg/openapi/spec.go
@@ -435,6 +435,38 @@ func buildSchemas() map[string]any {
 				},
 			},
 		},
+		"Asset": map[string]any{
+			"type":     "object",
+			"required": []string{"id", "url", "secureUrl", "publicId", "format", "resourceType", "bytes", "width", "height"},
+			"properties": map[string]any{
+				"id":           int64Schema("Database identifier."),
+				"url":          stringSchema("Direct URL for the uploaded asset."),
+				"secureUrl":    stringSchema("HTTPS URL for the uploaded asset."),
+				"publicId":     stringSchema("Cloudinary public identifier."),
+				"format":       stringSchema("File format reported by Cloudinary."),
+				"resourceType": stringSchema("Asset resource type such as image or video."),
+				"bytes":        int64Schema("File size in bytes."),
+				"width":        map[string]any{"type": "integer", "description": "Pixel width when available."},
+				"height":       map[string]any{"type": "integer", "description": "Pixel height when available."},
+			},
+		},
+		"AssetUploadRequest": map[string]any{
+			"type":     "object",
+			"required": []string{"file"},
+			"properties": map[string]any{
+				"file": map[string]any{
+					"type":        "string",
+					"format":      "binary",
+					"description": "Binary payload of the asset to upload.",
+				},
+			},
+		},
+		"AssetUploadResponse": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"asset": ref("Asset"),
+			},
+		},
 	}
 }
 
@@ -543,6 +575,30 @@ func buildPaths() map[string]any {
 				"responses": map[string]any{
 					"200": jsonResponse("Admin session revoked.", "AdminLogoutResponse"),
 					"401": noContent("Missing or invalid bearer token."),
+				},
+			},
+		},
+		"/v1/assets": map[string]any{
+			"post": map[string]any{
+				"operationId": "uploadAsset",
+				"summary":     "Upload a new asset",
+				"tags":        []string{"Assets"},
+				"security":    bearerSecurity,
+				"requestBody": map[string]any{
+					"required": true,
+					"content": map[string]any{
+						"multipart/form-data": map[string]any{
+							"schema": ref("AssetUploadRequest"),
+						},
+					},
+				},
+				"responses": map[string]any{
+					"201": jsonResponse("Asset uploaded.", "AssetUploadResponse"),
+					"400": noContent("Invalid upload payload or missing file."),
+					"403": noContent("Missing or invalid bearer token."),
+					"413": noContent("Uploaded file exceeds the maximum allowed size."),
+					"500": noContent("Failed to persist asset metadata."),
+					"502": noContent("Failed to upload asset to storage provider."),
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- add an authenticated `/v1/assets` handler that streams uploads to Cloudinary, enforces size limits, and persists metadata
- register the route, extend the OpenAPI document with asset schemas, and document usage in the API README
- add unit tests with stubbed dependencies covering success, validation failures, and upload errors

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f14c7177d8832cb449577044cfe0b2