### PR TITLE
Add optional project image URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ can remain storage agnostic. Metadata about each upload is persisted to the `ass
 `internal/data/assets.go`) which unlocks future join tables for connecting images to notes,
 projects or roles.
 
+When creating or updating a project (and future models that support rich images), the frontend
+should request an upload first, then include the resulting Cloudinary URL in the payload's optional
+`imageUrl` field.
+
 ### Tests
 Not a lot of tests yet, but hopefully changing soon. There are tests written for the `querybuilder` package. To run 
 these, run:

--- a/cmd/api/handler_projects.go
+++ b/cmd/api/handler_projects.go
@@ -30,6 +30,7 @@ func (app *application) getCreateProjectsHandler(w http.ResponseWriter, r *http.
 			EndDate     *time.Time `json:"endDate"`
 			Title       string     `json:"title"`
 			Description string     `json:"description"`
+			ImageURL    *string    `json:"imageUrl"`
 		}
 
 		err := app.readJSON(w, r, &input)
@@ -43,10 +44,8 @@ func (app *application) getCreateProjectsHandler(w http.ResponseWriter, r *http.
 			StartDate:   input.StartDate,
 			Title:       input.Title,
 			Description: input.Description,
-		}
-
-		if input.EndDate != nil {
-			project.EndDate = input.EndDate
+			EndDate:     input.EndDate,
+			ImageURL:    input.ImageURL,
 		}
 
 		err = app.models.Projects.Insert(project)
@@ -116,6 +115,7 @@ func (app *application) updateProject(w http.ResponseWriter, r *http.Request) {
 		EndDate     *time.Time `json:"endDate"`
 		Title       *string    `json:"title"`
 		Description *string    `json:"description"`
+		ImageURL    *string    `json:"imageUrl"`
 	}
 
 	err = app.readJSON(w, r, &input)
@@ -139,6 +139,10 @@ func (app *application) updateProject(w http.ResponseWriter, r *http.Request) {
 
 	if input.Description != nil {
 		project.Description = *input.Description
+	}
+
+	if input.ImageURL != nil {
+		project.ImageURL = input.ImageURL
 	}
 
 	err = app.models.Projects.Update(project)

--- a/internal/data/README.md
+++ b/internal/data/README.md
@@ -45,6 +45,7 @@ erDiagram
     date End_Date
     string Title
     text Description
+    string Image_URL
   }
 
   Tagged_Items {
@@ -120,7 +121,8 @@ CREATE TABLE IF NOT EXISTS projects (
   startDate timestamp(0) with time zone NOT NULL,
   endDate timestamp(0) with time zone,
   title text NOT NULL,
-  description text
+  description text,
+  imageUrl text
 );
 
 CREATE TABLE IF NOT EXISTS tags (
@@ -196,6 +198,16 @@ CREATE TABLE IF NOT EXISTS assets (
 -- );
 
 ```
+
+## Project image migration
+
+To extend the projects table with an optional image reference, run the following SQL against existing databases:
+
+```sql
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS imageUrl text;
+```
+
+Projects can now store the publicly accessible URL returned by the Cloudinary upload flow. Apply the same nullable column pattern to future content tables that need rich images.
 
 ## Notes table migration
 

--- a/internal/data/projects.go
+++ b/internal/data/projects.go
@@ -17,6 +17,7 @@ type Project struct {
 	EndDate     *time.Time `json:"endDate,omitempty"`
 	Title       string     `json:"title"`
 	Description string     `json:"description"`
+	ImageURL    *string    `json:"imageUrl,omitempty"`
 }
 
 type ProjectModel struct {
@@ -30,11 +31,17 @@ func (p ProjectModel) Insert(project *Project) error {
 		endDate = *project.EndDate
 	}
 
+	var imageURL interface{}
+	if project.ImageURL != nil {
+		imageURL = *project.ImageURL
+	}
+
 	values := querybuilder.Clauses{
 		{ColumnName: "startDate", Value: project.StartDate},
 		{ColumnName: "endDate", Value: endDate},
 		{ColumnName: "title", Value: project.Title},
 		{ColumnName: "description", Value: project.Description},
+		{ColumnName: "imageUrl", Value: imageURL},
 	}
 
 	row, err := p.Query.SetBaseTable("projects").Insert(values).Returning(
@@ -46,6 +53,7 @@ func (p ProjectModel) Insert(project *Project) error {
 		"endDate",
 		"title",
 		"description",
+		"imageUrl",
 	).QueryRow()
 	if err != nil {
 		return err
@@ -53,6 +61,7 @@ func (p ProjectModel) Insert(project *Project) error {
 
 	var deletedAt sql.NullTime
 	var savedEndDate sql.NullTime
+	var savedImageURL sql.NullString
 
 	err = row.Scan(
 		&project.ID,
@@ -63,6 +72,7 @@ func (p ProjectModel) Insert(project *Project) error {
 		&savedEndDate,
 		&project.Title,
 		&project.Description,
+		&savedImageURL,
 	)
 	if err != nil {
 		return err
@@ -78,6 +88,12 @@ func (p ProjectModel) Insert(project *Project) error {
 		project.EndDate = &savedEndDate.Time
 	} else {
 		project.EndDate = nil
+	}
+
+	if savedImageURL.Valid {
+		project.ImageURL = &savedImageURL.String
+	} else {
+		project.ImageURL = nil
 	}
 
 	return nil
@@ -97,6 +113,7 @@ func (p ProjectModel) Get(projectID int64) (*Project, error) {
 		"endDate",
 		"title",
 		"description",
+		"imageUrl",
 	).WhereEqual("deletedAt", nil).WhereEqual("id", projectID).QueryRow()
 	if err != nil {
 		return nil, err
@@ -105,6 +122,7 @@ func (p ProjectModel) Get(projectID int64) (*Project, error) {
 	var project Project
 	var deletedAt sql.NullTime
 	var endDate sql.NullTime
+	var imageURL sql.NullString
 
 	err = row.Scan(
 		&project.ID,
@@ -115,6 +133,7 @@ func (p ProjectModel) Get(projectID int64) (*Project, error) {
 		&endDate,
 		&project.Title,
 		&project.Description,
+		&imageURL,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -131,6 +150,10 @@ func (p ProjectModel) Get(projectID int64) (*Project, error) {
 		project.EndDate = &endDate.Time
 	}
 
+	if imageURL.Valid {
+		project.ImageURL = &imageURL.String
+	}
+
 	return &project, nil
 }
 
@@ -140,11 +163,17 @@ func (p ProjectModel) Update(project *Project) error {
 		endDate = *project.EndDate
 	}
 
+	var imageURL interface{}
+	if project.ImageURL != nil {
+		imageURL = *project.ImageURL
+	}
+
 	values := querybuilder.Clauses{
 		{ColumnName: "startDate", Value: project.StartDate},
 		{ColumnName: "endDate", Value: endDate},
 		{ColumnName: "title", Value: project.Title},
 		{ColumnName: "description", Value: project.Description},
+		{ColumnName: "imageUrl", Value: imageURL},
 		{ColumnName: "updatedAt", Value: time.Now()},
 	}
 
@@ -157,6 +186,7 @@ func (p ProjectModel) Update(project *Project) error {
 		"endDate",
 		"title",
 		"description",
+		"imageUrl",
 	).QueryRow()
 	if err != nil {
 		return err
@@ -164,6 +194,7 @@ func (p ProjectModel) Update(project *Project) error {
 
 	var deletedAt sql.NullTime
 	var savedEndDate sql.NullTime
+	var savedImageURL sql.NullString
 
 	err = row.Scan(
 		&project.ID,
@@ -174,6 +205,7 @@ func (p ProjectModel) Update(project *Project) error {
 		&savedEndDate,
 		&project.Title,
 		&project.Description,
+		&savedImageURL,
 	)
 	if err != nil {
 		return err
@@ -189,6 +221,12 @@ func (p ProjectModel) Update(project *Project) error {
 		project.EndDate = &savedEndDate.Time
 	} else {
 		project.EndDate = nil
+	}
+
+	if savedImageURL.Valid {
+		project.ImageURL = &savedImageURL.String
+	} else {
+		project.ImageURL = nil
 	}
 
 	return nil
@@ -231,6 +269,7 @@ func (p ProjectModel) GetAll() ([]*Project, error) {
 		"endDate",
 		"title",
 		"description",
+		"imageUrl",
 	).WhereEqual("deletedAt", nil).OrderBy("startDate", "desc").Query()
 	if err != nil {
 		return nil, err
@@ -244,6 +283,7 @@ func (p ProjectModel) GetAll() ([]*Project, error) {
 		var project Project
 		var deletedAt sql.NullTime
 		var endDate sql.NullTime
+		var imageURL sql.NullString
 
 		err := rows.Scan(
 			&project.ID,
@@ -254,6 +294,7 @@ func (p ProjectModel) GetAll() ([]*Project, error) {
 			&endDate,
 			&project.Title,
 			&project.Description,
+			&imageURL,
 		)
 		if err != nil {
 			return nil, err
@@ -265,6 +306,10 @@ func (p ProjectModel) GetAll() ([]*Project, error) {
 
 		if endDate.Valid {
 			project.EndDate = &endDate.Time
+		}
+
+		if imageURL.Valid {
+			project.ImageURL = &imageURL.String
 		}
 
 		projects = append(projects, &project)

--- a/pkg/openapi/spec.go
+++ b/pkg/openapi/spec.go
@@ -226,6 +226,7 @@ func buildSchemas() map[string]any {
 				"endDate":     dateTimeSchema("Project end date. Omitted while the project is ongoing."),
 				"title":       stringSchema("Project title."),
 				"description": stringSchema("Project description."),
+				"imageUrl":    stringSchema("Public URL of the project's lead image."),
 			},
 		},
 		"CreateProjectRequest": map[string]any{
@@ -236,6 +237,7 @@ func buildSchemas() map[string]any {
 				"endDate":     dateTimeSchema("Project end date. Omitted while the project is ongoing."),
 				"title":       stringSchema("Project title."),
 				"description": stringSchema("Project description."),
+				"imageUrl":    stringSchema("Public URL of the project's lead image."),
 			},
 		},
 		"UpdateProjectRequest": map[string]any{
@@ -245,6 +247,7 @@ func buildSchemas() map[string]any {
 				"endDate":     dateTimeSchema("Project end date. Omitted while the project is ongoing."),
 				"title":       stringSchema("Project title."),
 				"description": stringSchema("Project description."),
+				"imageUrl":    stringSchema("Public URL of the project's lead image."),
 			},
 		},
 		"ProjectResponse": map[string]any{


### PR DESCRIPTION
## Summary
- add a nullable `imageUrl` column for projects, document the migration, and persist it through the data model
- expose the optional project image URL via the API handlers and OpenAPI schemas
- document the frontend flow for uploading assets before submitting project changes

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f14fa45560832cb6ea8fe0429469a8