### PR TITLE
Fix NULL condition parameter binding in query builder

### DIFF
--- a/pkg/querybuilder/querybuilder.go
+++ b/pkg/querybuilder/querybuilder.go
@@ -146,9 +146,17 @@ func (q *QueryBuilder) buildConditionalStatement(conditions Clauses) string {
 func (q *QueryBuilder) buildParameters(parameters Clauses) []interface{} {
 	values := make([]interface{}, 0, len(parameters))
 	for _, clause := range parameters {
-		if clause.Value != "" {
-			values = append(values, clause.Value)
+		if strings.Contains(clause.ColumnName, ":") {
+			parts := strings.SplitN(clause.ColumnName, ":", 2)
+			if len(parts) == 2 {
+				comparer := parts[1]
+				if comparer == "IS NULL" || comparer == "IS NOT NULL" {
+					continue
+				}
+			}
 		}
+
+		values = append(values, clause.Value)
 	}
 	return values
 }

--- a/pkg/querybuilder/querybuilder_test.go
+++ b/pkg/querybuilder/querybuilder_test.go
@@ -105,6 +105,22 @@ func TestBuildParameters(t *testing.T) {
 	}
 }
 
+func TestBuildParameters_SkipsNullComparisons(t *testing.T) {
+	qb := QueryBuilder{}
+	parameters := Clauses{
+		{ColumnName: "deleted_at:IS NULL"},
+		{ColumnName: "category:=", Value: "admin"},
+		{ColumnName: "archived_at:IS NOT NULL"},
+	}
+
+	params := qb.buildParameters(parameters)
+
+	expectedParams := []interface{}{"admin"}
+	if !reflect.DeepEqual(params, expectedParams) {
+		t.Errorf("Expected parameters to be %v, got %v", expectedParams, params)
+	}
+}
+
 func TestBuildReturnedColumns(t *testing.T) {
 	qb := QueryBuilder{}
 	fields := []string{"id", "name", "email"}


### PR DESCRIPTION
## Summary
- update the query builder to skip binding parameters for NULL comparisons
- prevent SELECT queries from supplying superfluous arguments to statements without placeholders

## Testing
- go test ./... *(fails: hangs, likely awaiting external dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68f1aca8a810832ca9179cac6e44bcdb