### PR TITLE
Fix select query parameter handling for nil conditions

### DIFF
--- a/pkg/querybuilder/select.go
+++ b/pkg/querybuilder/select.go
@@ -91,8 +91,8 @@ func (q *SelectQueryBuilder) Query() (*sql.Rows, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(q.conditions) > 0 {
-		values := q.queryBuilder.buildParameters(q.conditions)
+	values := q.buildPreparedStatementValues()
+	if len(values) > 0 {
 		return q.queryBuilder.DB.Query(*query, values...)
 	}
 	return q.queryBuilder.DB.Query(*query)


### PR DESCRIPTION
## Summary
- ensure select query builder passes prepared parameters from both conditions and common table expressions
- avoid sending superfluous arguments for parameterless statements when querying rows

## Testing
- go test ./pkg/querybuilder

------
https://chatgpt.com/codex/tasks/task_e_68f1bb9d6a08832ca501c1ec501461ec