### PR TITLE
Avoid sending parameters with placeholder-free select queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 )
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
 	github.com/creasty/defaults v1.7.0 // indirect
 	github.com/google/uuid v1.5.0 // indirect
 	github.com/gorilla/schema v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/cloudinary/cloudinary-go/v2 v2.13.0 h1:ugiQwb7DwpWQnete2AZkTh94MonZKmxD7hDGy1qTzDs=
 github.com/cloudinary/cloudinary-go/v2 v2.13.0/go.mod h1:ireC4gqVetsjVhYlwjUJwKTbZuWjEIynbR9zQTlqsvo=
 github.com/creasty/defaults v1.7.0 h1:eNdqZvc5B509z18lD8yc212CAqJNvfT1Jq6L8WowdBA=

--- a/pkg/querybuilder/select.go
+++ b/pkg/querybuilder/select.go
@@ -92,7 +92,7 @@ func (q *SelectQueryBuilder) Query() (*sql.Rows, error) {
 		return nil, err
 	}
 	values := q.buildPreparedStatementValues()
-	if len(values) > 0 {
+	if q.queryBuilder.preparedVariableOffset > 0 {
 		return q.queryBuilder.DB.Query(*query, values...)
 	}
 	return q.queryBuilder.DB.Query(*query)
@@ -103,7 +103,7 @@ func (q *SelectQueryBuilder) QueryRow() (*sql.Row, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(q.conditions) > 0 || len(q.queryBuilder.commonTableExpressions) > 0 {
+	if q.queryBuilder.preparedVariableOffset > 0 {
 		values := q.buildPreparedStatementValues()
 		return q.queryBuilder.DB.QueryRow(*query, values...), nil
 	}

--- a/pkg/querybuilder/select_null_test.go
+++ b/pkg/querybuilder/select_null_test.go
@@ -1,0 +1,30 @@
+package querybuilder
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestSelectQueryBuilder_QueryWhereNullDoesNotSendArgs(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("unexpected error creating sqlmock: %s", err)
+	}
+	defer db.Close()
+
+	qb := QueryBuilder{DB: db}
+
+	mock.ExpectQuery("SELECT id FROM projects WHERE deletedAt IS NULL").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	rows, err := qb.SetBaseTable("projects").Select("id").WhereEqual("deletedAt", nil).Query()
+	if err != nil {
+		t.Fatalf("unexpected error querying: %s", err)
+	}
+	rows.Close()
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("there were unmet expectations: %s", err)
+	}
+}

--- a/pkg/querybuilder/select_null_values_test.go
+++ b/pkg/querybuilder/select_null_values_test.go
@@ -1,0 +1,18 @@
+package querybuilder
+
+import "testing"
+
+func TestSelectQueryBuilder_PreparedValuesForNullCondition(t *testing.T) {
+	qb := QueryBuilder{}
+	selectQB := qb.SetBaseTable("projects").Select("id", "title").WhereEqual("deletedAt", nil).OrderBy("startDate", "desc")
+
+	query, err := selectQB.buildQuery()
+	if err != nil {
+		t.Fatalf("unexpected error building query: %s", err)
+	}
+
+	values := selectQB.buildPreparedStatementValues()
+	if len(values) != 0 {
+		t.Fatalf("expected no prepared values, got %d for query %s", len(values), *query)
+	}
+}


### PR DESCRIPTION
## Summary
- update the select query builder to only send arguments when the query actually includes placeholders
- add regression tests to ensure null filters do not enqueue prepared statement parameters
- pull in sqlmock to support the new query builder tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f214f06688832c9cb5108745454edf