### PR TITLE
Automate OpenAPI spec management

### DIFF
--- a/.github/workflows/openapi-generate.yml
+++ b/.github/workflows/openapi-generate.yml
@@ -1,0 +1,178 @@
+name: Generate OpenAPI specification
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate:
+    if: github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check comment trigger
+        id: trigger
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          body_lower=$(echo "$COMMENT_BODY" | tr '[:upper:]' '[:lower:]')
+          if [[ "$body_lower" == *"generate openapi spec"* ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Acknowledge non-matching comment
+        if: steps.trigger.outputs.run != 'true'
+        run: echo "Comment does not request OpenAPI generation."
+
+      - name: Fetch pull request metadata
+        if: steps.trigger.outputs.run == 'true'
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('head_ref', pr.data.head.ref);
+            core.setOutput('head_repo', pr.data.head.repo.full_name);
+            core.setOutput('is_fork', pr.data.head.repo.fork ? 'true' : 'false');
+
+      - name: Comment for forked pull request
+        if: steps.trigger.outputs.run == 'true' && steps.pr.outputs.is_fork == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- openapi-generate -->';
+            const body = `${marker}
+Unable to update the OpenAPI document automatically for pull requests from forks.
+
+Please run go run ./cmd/openapi -output cmd/api/openapi.json locally and push the result.`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(comment => comment.body && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Check out pull request head
+        if: steps.trigger.outputs.run == 'true' && steps.pr.outputs.is_fork != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.pr.outputs.head_repo }}
+          ref: ${{ steps.pr.outputs.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        if: steps.trigger.outputs.run == 'true' && steps.pr.outputs.is_fork != 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Regenerate OpenAPI document
+        if: steps.trigger.outputs.run == 'true' && steps.pr.outputs.is_fork != 'true'
+        run: go run ./cmd/openapi -output cmd/api/openapi.json
+
+      - name: Detect spec updates
+        if: steps.trigger.outputs.run == 'true' && steps.pr.outputs.is_fork != 'true'
+        id: changes
+        run: |
+          if git diff --quiet -- cmd/api/openapi.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit specification changes
+        if: steps.trigger.outputs.run == 'true' && steps.pr.outputs.is_fork != 'true' && steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add cmd/api/openapi.json
+          git commit -m "chore: update OpenAPI spec"
+          git push
+
+      - name: Comment after update
+        if: steps.trigger.outputs.run == 'true' && steps.pr.outputs.is_fork != 'true' && steps.changes.outputs.changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- openapi-generate -->';
+            const body = `${marker}
+The OpenAPI document has been regenerated and pushed to this branch.`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(comment => comment.body && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Comment when no changes detected
+        if: steps.trigger.outputs.run == 'true' && steps.pr.outputs.is_fork != 'true' && steps.changes.outputs.changed != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- openapi-generate -->';
+            const body = `${marker}
+The OpenAPI document was already up to date.`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(comment => comment.body && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/openapi-validate.yml
+++ b/.github/workflows/openapi-validate.yml
@@ -1,0 +1,74 @@
+name: Validate OpenAPI specification
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate:
+    name: Check generated spec
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Generate OpenAPI document
+        run: go run ./cmd/openapi -output cmd/api/openapi.json
+
+      - name: Detect changes
+        id: diff
+        run: |
+          if git diff --quiet -- cmd/api/openapi.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff -- cmd/api/openapi.json > openapi.diff
+          fi
+
+      - name: Comment on pull request
+        if: steps.diff.outputs.changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- openapi-drift -->';
+            const body = `${marker}
+The generated OpenAPI document does not match the committed version.
+
+Run go run ./cmd/openapi -output cmd/api/openapi.json and commit the result, or comment "generate openapi spec" to have CI update it for you.`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(comment => comment.body && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail when spec is stale
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          echo "OpenAPI spec is out of date"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -98,9 +98,21 @@ should request an upload first, then include the resulting Cloudinary URL in the
 `imageUrl` field.
 
 ### Tests
-Not a lot of tests yet, but hopefully changing soon. There are tests written for the `querybuilder` package. To run 
+Not a lot of tests yet, but hopefully changing soon. There are tests written for the `querybuilder` package. To run
 these, run:
 
 ```bash
 go test -timeout 30s api.etin.dev/pkg/querybuilder
 ```
+
+### OpenAPI specification
+The `/swagger` endpoint serves a generated OpenAPI document embedded in the binary. To regenerate the specification after
+changing handlers or schemas, run:
+
+```bash
+go run ./cmd/openapi
+```
+
+This command rewrites `cmd/api/openapi.json`. Commit the updated file to keep the embedded schema in sync. Pull requests
+automatically verify that the committed document matches the generated output, and you can comment “generate openapi spec” on
+an open PR to trigger CI to regenerate and push the latest document for you.

--- a/cmd/api/handlers.go
+++ b/cmd/api/handlers.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"net/http"
+
+	"api.etin.dev/internal/version"
 )
 
 func (app *application) healthcheck(w http.ResponseWriter, r *http.Request) {
@@ -13,7 +15,7 @@ func (app *application) healthcheck(w http.ResponseWriter, r *http.Request) {
 	data := map[string]string{
 		"status":      "available",
 		"environment": app.config.env,
-		"version":     version,
+		"version":     version.Number,
 	}
 	j, err := json.Marshal(data)
 	if err != nil {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -12,11 +12,8 @@ import (
 
 	"api.etin.dev/internal/assets"
 	"api.etin.dev/internal/data"
-	"api.etin.dev/pkg/openapi"
 	_ "github.com/lib/pq"
 )
-
-const version = "1.0.0"
 
 type config struct {
 	port          int
@@ -107,11 +104,6 @@ func main() {
 		logger.Fatal(err)
 	}
 
-	swaggerDoc, err := openapi.Build(version)
-	if err != nil {
-		logger.Fatal(err)
-	}
-
 	models := data.NewModels(db)
 
 	app := &application{
@@ -120,7 +112,7 @@ func main() {
 		models:     models,
 		assetModel: models.Assets,
 		assets:     uploader,
-		swagger:    swaggerDoc,
+		swagger:    embeddedSwagger,
 		sessions:   newSessionManager(24 * time.Hour),
 	}
 

--- a/cmd/api/openapi.json
+++ b/cmd/api/openapi.json
@@ -1,0 +1,2354 @@
+{
+  "components": {
+    "schemas": {
+      "AdminLoginRequest": {
+        "properties": {
+          "email": {
+            "description": "Admin email address.",
+            "type": "string"
+          },
+          "password": {
+            "description": "Admin password.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "password"
+        ],
+        "type": "object"
+      },
+      "AdminLoginResponse": {
+        "properties": {
+          "expiresAt": {
+            "description": "Timestamp when the session token expires.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "token": {
+            "description": "Bearer token used to authenticate administrative requests.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "expiresAt"
+        ],
+        "type": "object"
+      },
+      "AdminLogoutResponse": {
+        "properties": {
+          "message": {
+            "description": "Confirmation message.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Asset": {
+        "properties": {
+          "bytes": {
+            "description": "File size in bytes.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "format": {
+            "description": "File format reported by Cloudinary.",
+            "type": "string"
+          },
+          "height": {
+            "description": "Pixel height when available.",
+            "type": "integer"
+          },
+          "id": {
+            "description": "Database identifier.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "publicId": {
+            "description": "Cloudinary public identifier.",
+            "type": "string"
+          },
+          "resourceType": {
+            "description": "Asset resource type such as image or video.",
+            "type": "string"
+          },
+          "secureUrl": {
+            "description": "HTTPS URL for the uploaded asset.",
+            "type": "string"
+          },
+          "url": {
+            "description": "Direct URL for the uploaded asset.",
+            "type": "string"
+          },
+          "width": {
+            "description": "Pixel width when available.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "url",
+          "secureUrl",
+          "publicId",
+          "format",
+          "resourceType",
+          "bytes",
+          "width",
+          "height"
+        ],
+        "type": "object"
+      },
+      "AssetUploadRequest": {
+        "properties": {
+          "file": {
+            "description": "Binary payload of the asset to upload.",
+            "format": "binary",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "type": "object"
+      },
+      "AssetUploadResponse": {
+        "properties": {
+          "asset": {
+            "$ref": "#/components/schemas/Asset"
+          }
+        },
+        "type": "object"
+      },
+      "CompaniesResponse": {
+        "properties": {
+          "companies": {
+            "items": {
+              "$ref": "#/components/schemas/Company"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "Company": {
+        "properties": {
+          "description": {
+            "description": "Markdown description for the company.",
+            "type": "string"
+          },
+          "icon": {
+            "description": "Icon URL for the company.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Database identifier.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "name": {
+            "description": "Company display name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "icon",
+          "description"
+        ],
+        "type": "object"
+      },
+      "CompanyRequest": {
+        "properties": {
+          "description": {
+            "description": "Markdown description for the company.",
+            "type": "string"
+          },
+          "icon": {
+            "description": "Icon URL for the company.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Company display name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "CompanyResponse": {
+        "properties": {
+          "company": {
+            "$ref": "#/components/schemas/Company"
+          }
+        },
+        "type": "object"
+      },
+      "CreateItemNoteRequest": {
+        "properties": {
+          "itemId": {
+            "description": "Linked item identifier.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "itemType": {
+            "description": "Type of item linked to the note.",
+            "enum": [
+              "notes",
+              "roles",
+              "projects"
+            ],
+            "type": "string"
+          },
+          "noteId": {
+            "description": "Linked note identifier.",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "noteId",
+          "itemId",
+          "itemType"
+        ],
+        "type": "object"
+      },
+      "CreateNoteRequest": {
+        "properties": {
+          "body": {
+            "description": "Note body in Markdown.",
+            "type": "string"
+          },
+          "publishedAt": {
+            "description": "Publication timestamp.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "subtitle": {
+            "description": "Note subtitle.",
+            "type": "string"
+          },
+          "title": {
+            "description": "Note title.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "CreateProjectRequest": {
+        "properties": {
+          "description": {
+            "description": "Project description.",
+            "type": "string"
+          },
+          "endDate": {
+            "description": "Project end date. Omitted while the project is ongoing.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "imageUrl": {
+            "description": "Public URL of the project's lead image.",
+            "type": "string"
+          },
+          "startDate": {
+            "description": "Project start date.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "title": {
+            "description": "Project title.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "startDate",
+          "title",
+          "description"
+        ],
+        "type": "object"
+      },
+      "CreateRoleRequest": {
+        "properties": {
+          "companyId": {
+            "description": "Identifier for the related company.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "description": {
+            "description": "Markdown description of responsibilities.",
+            "type": "string"
+          },
+          "endDate": {
+            "description": "Employment end date. Zero timestamp indicates an ongoing role.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "skills": {
+            "items": {
+              "description": "Skill associated with the role.",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "startDate": {
+            "description": "Employment start date.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "subtitle": {
+            "description": "Role subtitle.",
+            "type": "string"
+          },
+          "title": {
+            "description": "Role title.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "startDate",
+          "title",
+          "companyId",
+          "skills"
+        ],
+        "type": "object"
+      },
+      "CreateTagItemRequest": {
+        "properties": {
+          "itemId": {
+            "description": "Linked item identifier.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "itemType": {
+            "description": "Type of item linked to the tag.",
+            "enum": [
+              "notes",
+              "roles",
+              "projects"
+            ],
+            "type": "string"
+          },
+          "tagId": {
+            "description": "Linked tag identifier.",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "tagId",
+          "itemId",
+          "itemType"
+        ],
+        "type": "object"
+      },
+      "HealthcheckResponse": {
+        "properties": {
+          "environment": {
+            "description": "Deployment environment for the running service.",
+            "type": "string"
+          },
+          "status": {
+            "description": "Service availability status.",
+            "type": "string"
+          },
+          "version": {
+            "description": "Semantic version of the running service.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "environment",
+          "version"
+        ],
+        "type": "object"
+      },
+      "ItemNote": {
+        "properties": {
+          "id": {
+            "description": "Database identifier.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "itemId": {
+            "description": "Linked item identifier.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "itemType": {
+            "description": "Type of item linked to the note.",
+            "enum": [
+              "notes",
+              "roles",
+              "projects"
+            ],
+            "type": "string"
+          },
+          "noteId": {
+            "description": "Linked note identifier.",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "noteId",
+          "itemId",
+          "itemType"
+        ],
+        "type": "object"
+      },
+      "ItemNoteResponse": {
+        "properties": {
+          "itemNote": {
+            "$ref": "#/components/schemas/ItemNote"
+          }
+        },
+        "type": "object"
+      },
+      "ItemNotesResponse": {
+        "properties": {
+          "itemNotes": {
+            "items": {
+              "$ref": "#/components/schemas/ItemNote"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "Note": {
+        "properties": {
+          "body": {
+            "description": "Note body in Markdown.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Database identifier.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "publishedAt": {
+            "description": "Publication timestamp.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "subtitle": {
+            "description": "Note subtitle.",
+            "type": "string"
+          },
+          "title": {
+            "description": "Note title.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "subtitle",
+          "body"
+        ],
+        "type": "object"
+      },
+      "NoteResponse": {
+        "properties": {
+          "note": {
+            "$ref": "#/components/schemas/Note"
+          }
+        },
+        "type": "object"
+      },
+      "NotesResponse": {
+        "properties": {
+          "notes": {
+            "items": {
+              "$ref": "#/components/schemas/Note"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "Project": {
+        "properties": {
+          "description": {
+            "description": "Project description.",
+            "type": "string"
+          },
+          "endDate": {
+            "description": "Project end date. Omitted while the project is ongoing.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "Database identifier.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "imageUrl": {
+            "description": "Public URL of the project's lead image.",
+            "type": "string"
+          },
+          "startDate": {
+            "description": "Project start date.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "title": {
+            "description": "Project title.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "startDate",
+          "title",
+          "description"
+        ],
+        "type": "object"
+      },
+      "ProjectResponse": {
+        "properties": {
+          "project": {
+            "$ref": "#/components/schemas/Project"
+          }
+        },
+        "type": "object"
+      },
+      "ProjectsResponse": {
+        "properties": {
+          "projects": {
+            "items": {
+              "$ref": "#/components/schemas/Project"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "Role": {
+        "properties": {
+          "company": {
+            "description": "Resolved company name.",
+            "type": "string"
+          },
+          "companyIcon": {
+            "description": "Resolved company icon.",
+            "type": "string"
+          },
+          "companyId": {
+            "description": "Identifier for the related company.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "description": {
+            "description": "Markdown description of responsibilities.",
+            "type": "string"
+          },
+          "endDate": {
+            "description": "Employment end date. Zero timestamp indicates an ongoing role.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "Database identifier.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "skills": {
+            "items": {
+              "description": "Skill associated with the role.",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "slug": {
+            "description": "URL slug for the role.",
+            "type": "string"
+          },
+          "startDate": {
+            "description": "Employment start date.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "subtitle": {
+            "description": "Role subtitle.",
+            "type": "string"
+          },
+          "title": {
+            "description": "Role title.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "startDate",
+          "endDate",
+          "title",
+          "subtitle",
+          "companyId",
+          "company",
+          "companyIcon",
+          "slug",
+          "description",
+          "skills"
+        ],
+        "type": "object"
+      },
+      "RoleResponse": {
+        "properties": {
+          "role": {
+            "$ref": "#/components/schemas/Role"
+          }
+        },
+        "type": "object"
+      },
+      "RolesResponse": {
+        "properties": {
+          "roles": {
+            "items": {
+              "$ref": "#/components/schemas/Role"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "Tag": {
+        "properties": {
+          "icon": {
+            "description": "Optional emoji or icon for the tag.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Database identifier.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "name": {
+            "description": "Tag display name.",
+            "type": "string"
+          },
+          "slug": {
+            "description": "URL slug for the tag.",
+            "type": "string"
+          },
+          "theme": {
+            "description": "Optional theme identifier for the tag.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "slug"
+        ],
+        "type": "object"
+      },
+      "TagItem": {
+        "properties": {
+          "id": {
+            "description": "Database identifier.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "itemId": {
+            "description": "Linked item identifier.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "itemType": {
+            "description": "Type of item linked to the tag.",
+            "enum": [
+              "notes",
+              "roles",
+              "projects"
+            ],
+            "type": "string"
+          },
+          "tagId": {
+            "description": "Linked tag identifier.",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "tagId",
+          "itemId",
+          "itemType"
+        ],
+        "type": "object"
+      },
+      "TagItemResponse": {
+        "properties": {
+          "taggedItem": {
+            "$ref": "#/components/schemas/TagItem"
+          }
+        },
+        "type": "object"
+      },
+      "TagItemsResponse": {
+        "properties": {
+          "taggedItems": {
+            "items": {
+              "$ref": "#/components/schemas/TagItem"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "TagsResponse": {
+        "properties": {
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "UpdateCompanyRequest": {
+        "properties": {
+          "description": {
+            "description": "Markdown description for the company.",
+            "type": "string"
+          },
+          "icon": {
+            "description": "Icon URL for the company.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Company display name.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "UpdateItemNoteRequest": {
+        "properties": {
+          "itemId": {
+            "description": "Linked item identifier.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "itemType": {
+            "description": "Type of item linked to the note.",
+            "enum": [
+              "notes",
+              "roles",
+              "projects"
+            ],
+            "type": "string"
+          },
+          "noteId": {
+            "description": "Linked note identifier.",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "UpdateNoteRequest": {
+        "properties": {
+          "body": {
+            "description": "Note body in Markdown.",
+            "type": "string"
+          },
+          "publishedAt": {
+            "description": "Publication timestamp.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "subtitle": {
+            "description": "Note subtitle.",
+            "type": "string"
+          },
+          "title": {
+            "description": "Note title.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "UpdateProjectRequest": {
+        "properties": {
+          "description": {
+            "description": "Project description.",
+            "type": "string"
+          },
+          "endDate": {
+            "description": "Project end date. Omitted while the project is ongoing.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "imageUrl": {
+            "description": "Public URL of the project's lead image.",
+            "type": "string"
+          },
+          "startDate": {
+            "description": "Project start date.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "title": {
+            "description": "Project title.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "UpdateRoleRequest": {
+        "properties": {
+          "companyId": {
+            "description": "Identifier for the related company.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "description": {
+            "description": "Markdown description of responsibilities.",
+            "type": "string"
+          },
+          "endDate": {
+            "description": "Employment end date. Zero timestamp indicates an ongoing role.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "skills": {
+            "items": {
+              "description": "Skill associated with the role.",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "startDate": {
+            "description": "Employment start date.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "subtitle": {
+            "description": "Role subtitle.",
+            "type": "string"
+          },
+          "title": {
+            "description": "Role title.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "UpdateTagItemRequest": {
+        "properties": {
+          "itemId": {
+            "description": "Linked item identifier.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "itemType": {
+            "description": "Type of item linked to the tag.",
+            "enum": [
+              "notes",
+              "roles",
+              "projects"
+            ],
+            "type": "string"
+          },
+          "tagId": {
+            "description": "Linked tag identifier.",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "bearerFormat": "opaque token",
+        "description": "Bearer token issued by the admin login endpoint.",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "description": "Backend API powering api.etin.dev.",
+    "title": "api.etin.dev",
+    "version": "1.0.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/swagger": {
+      "get": {
+        "operationId": "getSwaggerDocument",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OpenAPI document for the API."
+          }
+        },
+        "summary": "Retrieve the OpenAPI specification",
+        "tags": [
+          "Documentation"
+        ]
+      }
+    },
+    "/v1/admin/login": {
+      "post": {
+        "operationId": "adminLogin",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminLoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminLoginResponse"
+                }
+              }
+            },
+            "description": "Admin session created."
+          },
+          "400": {
+            "description": "Invalid credentials payload."
+          },
+          "401": {
+            "description": "Invalid admin credentials."
+          }
+        },
+        "summary": "Create an admin session token",
+        "tags": [
+          "Administration"
+        ]
+      }
+    },
+    "/v1/admin/logout": {
+      "post": {
+        "operationId": "adminLogout",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminLogoutResponse"
+                }
+              }
+            },
+            "description": "Admin session revoked."
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Invalidate the current admin session token",
+        "tags": [
+          "Administration"
+        ]
+      }
+    },
+    "/v1/assets": {
+      "post": {
+        "operationId": "uploadAsset",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/AssetUploadRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetUploadResponse"
+                }
+              }
+            },
+            "description": "Asset uploaded."
+          },
+          "400": {
+            "description": "Invalid upload payload or missing file."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          },
+          "413": {
+            "description": "Uploaded file exceeds the maximum allowed size."
+          },
+          "500": {
+            "description": "Failed to persist asset metadata."
+          },
+          "502": {
+            "description": "Failed to upload asset to storage provider."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Upload a new asset",
+        "tags": [
+          "Assets"
+        ]
+      }
+    },
+    "/v1/companies": {
+      "get": {
+        "operationId": "listCompanies",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompaniesResponse"
+                }
+              }
+            },
+            "description": "Companies retrieved."
+          },
+          "500": {
+            "description": "Server error retrieving companies."
+          }
+        },
+        "summary": "List companies",
+        "tags": [
+          "Companies"
+        ]
+      },
+      "post": {
+        "operationId": "createCompany",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCompanyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompanyResponse"
+                }
+              }
+            },
+            "description": "Company created."
+          },
+          "400": {
+            "description": "Invalid payload."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create a company",
+        "tags": [
+          "Companies"
+        ]
+      }
+    },
+    "/v1/companies/{companyId}": {
+      "delete": {
+        "operationId": "deleteCompany",
+        "parameters": [
+          {
+            "description": "Identifier of the company.",
+            "in": "path",
+            "name": "companyId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Company deleted."
+          },
+          "400": {
+            "description": "Invalid company identifier."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          },
+          "500": {
+            "description": "Server error deleting company."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Delete a company",
+        "tags": [
+          "Companies"
+        ]
+      },
+      "get": {
+        "operationId": "getCompany",
+        "parameters": [
+          {
+            "description": "Identifier of the company.",
+            "in": "path",
+            "name": "companyId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompanyResponse"
+                }
+              }
+            },
+            "description": "Company retrieved."
+          },
+          "400": {
+            "description": "Invalid company identifier."
+          },
+          "500": {
+            "description": "Server error retrieving company."
+          }
+        },
+        "summary": "Retrieve a company",
+        "tags": [
+          "Companies"
+        ]
+      },
+      "put": {
+        "operationId": "updateCompany",
+        "parameters": [
+          {
+            "description": "Identifier of the company.",
+            "in": "path",
+            "name": "companyId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCompanyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompanyResponse"
+                }
+              }
+            },
+            "description": "Company updated."
+          },
+          "400": {
+            "description": "Invalid payload."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          },
+          "500": {
+            "description": "Server error updating company."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Update a company",
+        "tags": [
+          "Companies"
+        ]
+      }
+    },
+    "/v1/healthcheck": {
+      "get": {
+        "operationId": "getHealthcheck",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthcheckResponse"
+                }
+              }
+            },
+            "description": "Service is available."
+          }
+        },
+        "summary": "Check service health",
+        "tags": [
+          "Health"
+        ]
+      }
+    },
+    "/v1/item-notes": {
+      "get": {
+        "operationId": "listItemNotes",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemNotesResponse"
+                }
+              }
+            },
+            "description": "Item note associations retrieved."
+          },
+          "500": {
+            "description": "Server error retrieving item note associations."
+          }
+        },
+        "summary": "List item-note links",
+        "tags": [
+          "Item Notes"
+        ]
+      },
+      "post": {
+        "operationId": "createItemNote",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateItemNoteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemNoteResponse"
+                }
+              }
+            },
+            "description": "Item note association created."
+          },
+          "400": {
+            "description": "Invalid payload."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create an item-note link",
+        "tags": [
+          "Item Notes"
+        ]
+      }
+    },
+    "/v1/item-notes/items/{itemType}/{itemId}": {
+      "get": {
+        "operationId": "listNotesForItem",
+        "parameters": [
+          {
+            "description": "Type of item to fetch related records for.",
+            "in": "path",
+            "name": "itemType",
+            "required": true,
+            "schema": {
+              "enum": [
+                "notes",
+                "roles",
+                "projects"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Identifier of the item to fetch related records for.",
+            "in": "path",
+            "name": "itemId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotesResponse"
+                }
+              }
+            },
+            "description": "Notes retrieved."
+          },
+          "400": {
+            "description": "Invalid item type or identifier."
+          },
+          "500": {
+            "description": "Server error retrieving notes for the item."
+          }
+        },
+        "summary": "List notes associated with an item",
+        "tags": [
+          "Item Notes"
+        ]
+      }
+    },
+    "/v1/item-notes/{itemNoteId}": {
+      "delete": {
+        "operationId": "deleteItemNote",
+        "parameters": [
+          {
+            "description": "Identifier of the item-note link.",
+            "in": "path",
+            "name": "itemNoteId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Item note association deleted."
+          },
+          "400": {
+            "description": "Invalid item-note identifier."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          },
+          "404": {
+            "description": "Item note association not found."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Delete an item-note link",
+        "tags": [
+          "Item Notes"
+        ]
+      },
+      "get": {
+        "operationId": "getItemNote",
+        "parameters": [
+          {
+            "description": "Identifier of the item-note link.",
+            "in": "path",
+            "name": "itemNoteId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemNoteResponse"
+                }
+              }
+            },
+            "description": "Item note association retrieved."
+          },
+          "400": {
+            "description": "Invalid item-note identifier."
+          },
+          "404": {
+            "description": "Item note association not found."
+          }
+        },
+        "summary": "Retrieve an item-note link",
+        "tags": [
+          "Item Notes"
+        ]
+      },
+      "put": {
+        "operationId": "updateItemNote",
+        "parameters": [
+          {
+            "description": "Identifier of the item-note link.",
+            "in": "path",
+            "name": "itemNoteId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateItemNoteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemNoteResponse"
+                }
+              }
+            },
+            "description": "Item note association updated."
+          },
+          "400": {
+            "description": "Invalid payload."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          },
+          "404": {
+            "description": "Item note association not found."
+          },
+          "500": {
+            "description": "Server error updating item note association."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Update an item-note link",
+        "tags": [
+          "Item Notes"
+        ]
+      }
+    },
+    "/v1/notes": {
+      "get": {
+        "operationId": "listNotes",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotesResponse"
+                }
+              }
+            },
+            "description": "Notes retrieved."
+          },
+          "500": {
+            "description": "Server error retrieving notes."
+          }
+        },
+        "summary": "List notes",
+        "tags": [
+          "Notes"
+        ]
+      },
+      "post": {
+        "operationId": "createNote",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateNoteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoteResponse"
+                }
+              }
+            },
+            "description": "Note created."
+          },
+          "400": {
+            "description": "Invalid payload."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create a note",
+        "tags": [
+          "Notes"
+        ]
+      }
+    },
+    "/v1/notes/{noteId}": {
+      "delete": {
+        "operationId": "deleteNote",
+        "parameters": [
+          {
+            "description": "Identifier of the note.",
+            "in": "path",
+            "name": "noteId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Note deleted."
+          },
+          "400": {
+            "description": "Invalid note identifier."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          },
+          "404": {
+            "description": "Note not found."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Delete a note",
+        "tags": [
+          "Notes"
+        ]
+      },
+      "get": {
+        "operationId": "getNote",
+        "parameters": [
+          {
+            "description": "Identifier of the note.",
+            "in": "path",
+            "name": "noteId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoteResponse"
+                }
+              }
+            },
+            "description": "Note retrieved."
+          },
+          "400": {
+            "description": "Invalid note identifier."
+          },
+          "404": {
+            "description": "Note not found."
+          }
+        },
+        "summary": "Retrieve a note",
+        "tags": [
+          "Notes"
+        ]
+      },
+      "put": {
+        "operationId": "updateNote",
+        "parameters": [
+          {
+            "description": "Identifier of the note.",
+            "in": "path",
+            "name": "noteId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateNoteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoteResponse"
+                }
+              }
+            },
+            "description": "Note updated."
+          },
+          "400": {
+            "description": "Invalid payload."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          },
+          "404": {
+            "description": "Note not found."
+          },
+          "500": {
+            "description": "Server error updating note."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Update a note",
+        "tags": [
+          "Notes"
+        ]
+      }
+    },
+    "/v1/projects": {
+      "get": {
+        "operationId": "listProjects",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectsResponse"
+                }
+              }
+            },
+            "description": "Projects retrieved."
+          },
+          "500": {
+            "description": "Server error retrieving projects."
+          }
+        },
+        "summary": "List projects",
+        "tags": [
+          "Projects"
+        ]
+      },
+      "post": {
+        "operationId": "createProject",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateProjectRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResponse"
+                }
+              }
+            },
+            "description": "Project created."
+          },
+          "400": {
+            "description": "Invalid payload."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create a project",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/v1/projects/{projectId}": {
+      "delete": {
+        "operationId": "deleteProject",
+        "parameters": [
+          {
+            "description": "Identifier of the project.",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Project deleted."
+          },
+          "400": {
+            "description": "Invalid project identifier."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          },
+          "404": {
+            "description": "Project not found."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Delete a project",
+        "tags": [
+          "Projects"
+        ]
+      },
+      "get": {
+        "operationId": "getProject",
+        "parameters": [
+          {
+            "description": "Identifier of the project.",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResponse"
+                }
+              }
+            },
+            "description": "Project retrieved."
+          },
+          "400": {
+            "description": "Invalid project identifier."
+          },
+          "404": {
+            "description": "Project not found."
+          }
+        },
+        "summary": "Retrieve a project",
+        "tags": [
+          "Projects"
+        ]
+      },
+      "put": {
+        "operationId": "updateProject",
+        "parameters": [
+          {
+            "description": "Identifier of the project.",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProjectRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResponse"
+                }
+              }
+            },
+            "description": "Project updated."
+          },
+          "400": {
+            "description": "Invalid payload."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          },
+          "404": {
+            "description": "Project not found."
+          },
+          "500": {
+            "description": "Server error updating project."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Update a project",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/v1/roles": {
+      "get": {
+        "operationId": "listRoles",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RolesResponse"
+                }
+              }
+            },
+            "description": "Roles retrieved."
+          },
+          "500": {
+            "description": "Server error retrieving roles."
+          }
+        },
+        "summary": "List roles",
+        "tags": [
+          "Roles"
+        ]
+      },
+      "post": {
+        "operationId": "createRole",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleResponse"
+                }
+              }
+            },
+            "description": "Role created."
+          },
+          "400": {
+            "description": "Invalid payload."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create a role",
+        "tags": [
+          "Roles"
+        ]
+      }
+    },
+    "/v1/roles/{roleId}": {
+      "delete": {
+        "operationId": "deleteRole",
+        "parameters": [
+          {
+            "description": "Identifier of the role.",
+            "in": "path",
+            "name": "roleId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Role deleted."
+          },
+          "400": {
+            "description": "Invalid role identifier."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          },
+          "404": {
+            "description": "Role not found."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Delete a role",
+        "tags": [
+          "Roles"
+        ]
+      },
+      "get": {
+        "operationId": "getRole",
+        "parameters": [
+          {
+            "description": "Identifier of the role.",
+            "in": "path",
+            "name": "roleId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleResponse"
+                }
+              }
+            },
+            "description": "Role retrieved."
+          },
+          "400": {
+            "description": "Invalid role identifier."
+          },
+          "404": {
+            "description": "Role not found."
+          }
+        },
+        "summary": "Retrieve a role",
+        "tags": [
+          "Roles"
+        ]
+      },
+      "put": {
+        "operationId": "updateRole",
+        "parameters": [
+          {
+            "description": "Identifier of the role.",
+            "in": "path",
+            "name": "roleId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleResponse"
+                }
+              }
+            },
+            "description": "Role updated."
+          },
+          "400": {
+            "description": "Invalid payload."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          },
+          "404": {
+            "description": "Role not found."
+          },
+          "500": {
+            "description": "Server error updating role."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Update a role",
+        "tags": [
+          "Roles"
+        ]
+      }
+    },
+    "/v1/tagged-items": {
+      "get": {
+        "operationId": "listTagItems",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagItemsResponse"
+                }
+              }
+            },
+            "description": "Tag associations retrieved."
+          },
+          "500": {
+            "description": "Server error retrieving tag associations."
+          }
+        },
+        "summary": "List tag associations",
+        "tags": [
+          "Tag Items"
+        ]
+      },
+      "post": {
+        "operationId": "createTagItem",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTagItemRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagItemResponse"
+                }
+              }
+            },
+            "description": "Tag association created."
+          },
+          "400": {
+            "description": "Invalid payload."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create a tag association",
+        "tags": [
+          "Tag Items"
+        ]
+      }
+    },
+    "/v1/tagged-items/items/{itemType}/{itemId}": {
+      "get": {
+        "operationId": "listTagsForItem",
+        "parameters": [
+          {
+            "description": "Type of item to fetch related records for.",
+            "in": "path",
+            "name": "itemType",
+            "required": true,
+            "schema": {
+              "enum": [
+                "notes",
+                "roles",
+                "projects"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Identifier of the item to fetch related records for.",
+            "in": "path",
+            "name": "itemId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagsResponse"
+                }
+              }
+            },
+            "description": "Tags retrieved."
+          },
+          "400": {
+            "description": "Invalid item type or identifier."
+          },
+          "500": {
+            "description": "Server error retrieving tags for the item."
+          }
+        },
+        "summary": "List tags associated with an item",
+        "tags": [
+          "Tag Items"
+        ]
+      }
+    },
+    "/v1/tagged-items/{taggedItemId}": {
+      "delete": {
+        "operationId": "deleteTagItem",
+        "parameters": [
+          {
+            "description": "Identifier of the tag association.",
+            "in": "path",
+            "name": "taggedItemId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Tag association deleted."
+          },
+          "400": {
+            "description": "Invalid tag association identifier."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          },
+          "404": {
+            "description": "Tag association not found."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Delete a tag association",
+        "tags": [
+          "Tag Items"
+        ]
+      },
+      "get": {
+        "operationId": "getTagItem",
+        "parameters": [
+          {
+            "description": "Identifier of the tag association.",
+            "in": "path",
+            "name": "taggedItemId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagItemResponse"
+                }
+              }
+            },
+            "description": "Tag association retrieved."
+          },
+          "400": {
+            "description": "Invalid tag association identifier."
+          },
+          "404": {
+            "description": "Tag association not found."
+          }
+        },
+        "summary": "Retrieve a tag association",
+        "tags": [
+          "Tag Items"
+        ]
+      },
+      "put": {
+        "operationId": "updateTagItem",
+        "parameters": [
+          {
+            "description": "Identifier of the tag association.",
+            "in": "path",
+            "name": "taggedItemId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTagItemRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagItemResponse"
+                }
+              }
+            },
+            "description": "Tag association updated."
+          },
+          "400": {
+            "description": "Invalid payload."
+          },
+          "403": {
+            "description": "Missing or invalid bearer token."
+          },
+          "404": {
+            "description": "Tag association not found."
+          },
+          "500": {
+            "description": "Server error updating tag association."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Update a tag association",
+        "tags": [
+          "Tag Items"
+        ]
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://api.etin.dev"
+    },
+    {
+      "url": "http://localhost:4000"
+    }
+  ]
+}

--- a/cmd/api/swagger_embed.go
+++ b/cmd/api/swagger_embed.go
@@ -1,0 +1,12 @@
+package main
+
+import _ "embed"
+
+//go:embed openapi.json
+var embeddedSwagger []byte
+
+func init() {
+	if len(embeddedSwagger) == 0 {
+		panic("embedded OpenAPI document is empty")
+	}
+}

--- a/cmd/openapi/main.go
+++ b/cmd/openapi/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"api.etin.dev/internal/version"
+	"api.etin.dev/pkg/openapi"
+)
+
+func main() {
+	var output string
+	flag.StringVar(&output, "output", "cmd/api/openapi.json", "path to write the OpenAPI specification")
+	flag.Parse()
+
+	spec, err := openapi.Build(version.Number)
+	if err != nil {
+		log.Fatalf("generate openapi spec: %v", err)
+	}
+
+	if err := os.WriteFile(output, spec, 0o644); err != nil {
+		log.Fatalf("write openapi spec: %v", err)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+const Number = "1.0.0"


### PR DESCRIPTION
## Summary
- embed the generated OpenAPI document in the API binary and share the version constant
- add a `cmd/openapi` helper and committed `cmd/api/openapi.json` for manual regeneration
- introduce CI workflows to verify the spec and regenerate it on request via PR comments

## Testing
- go run ./cmd/openapi
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f37115fd88832cb86b1d74ca8de9ea