### PR TITLE
Fix OpenAPI generation workflow trigger

### DIFF
--- a/.github/workflows/openapi-generate.yml
+++ b/.github/workflows/openapi-generate.yml
@@ -3,14 +3,19 @@ name: Generate OpenAPI specification
 on:
   issue_comment:
     types: [created]
+  pull_request_review_comment:
+    types: [created]
 
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   generate:
-    if: github.event.issue.pull_request != null
+    if: >-
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) ||
+      github.event_name == 'pull_request_review_comment'
     runs-on: ubuntu-latest
     steps:
       - name: Check comment trigger
@@ -35,21 +40,28 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const prNumber = context.eventName === 'issue_comment'
+              ? context.payload.issue.number
+              : context.payload.pull_request.number;
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number,
+              pull_number: prNumber,
             });
             core.setOutput('head_ref', pr.data.head.ref);
             core.setOutput('head_repo', pr.data.head.repo.full_name);
             core.setOutput('is_fork', pr.data.head.repo.fork ? 'true' : 'false');
+            core.setOutput('number', String(prNumber));
 
       - name: Comment for forked pull request
         if: steps.trigger.outputs.run == 'true' && steps.pr.outputs.is_fork == 'true'
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           script: |
             const marker = '<!-- openapi-generate -->';
+            const issueNumber = Number(process.env.PR_NUMBER);
             const body = `${marker}
 Unable to update the OpenAPI document automatically for pull requests from forks.
 
@@ -57,7 +69,7 @@ Please run go run ./cmd/openapi -output cmd/api/openapi.json locally and push th
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: issueNumber,
               per_page: 100,
             });
             const existing = comments.find(comment => comment.body && comment.body.includes(marker));
@@ -72,7 +84,7 @@ Please run go run ./cmd/openapi -output cmd/api/openapi.json locally and push th
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: issueNumber,
                 body,
               });
             }
@@ -118,15 +130,18 @@ Please run go run ./cmd/openapi -output cmd/api/openapi.json locally and push th
       - name: Comment after update
         if: steps.trigger.outputs.run == 'true' && steps.pr.outputs.is_fork != 'true' && steps.changes.outputs.changed == 'true'
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           script: |
             const marker = '<!-- openapi-generate -->';
+            const issueNumber = Number(process.env.PR_NUMBER);
             const body = `${marker}
 The OpenAPI document has been regenerated and pushed to this branch.`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: issueNumber,
               per_page: 100,
             });
             const existing = comments.find(comment => comment.body && comment.body.includes(marker));
@@ -141,7 +156,7 @@ The OpenAPI document has been regenerated and pushed to this branch.`;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: issueNumber,
                 body,
               });
             }
@@ -149,15 +164,18 @@ The OpenAPI document has been regenerated and pushed to this branch.`;
       - name: Comment when no changes detected
         if: steps.trigger.outputs.run == 'true' && steps.pr.outputs.is_fork != 'true' && steps.changes.outputs.changed != 'true'
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           script: |
             const marker = '<!-- openapi-generate -->';
+            const issueNumber = Number(process.env.PR_NUMBER);
             const body = `${marker}
 The OpenAPI document was already up to date.`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: issueNumber,
               per_page: 100,
             });
             const existing = comments.find(comment => comment.body && comment.body.includes(marker));
@@ -172,7 +190,7 @@ The OpenAPI document was already up to date.`;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: issueNumber,
                 body,
               });
             }


### PR DESCRIPTION
## Summary
- trigger the OpenAPI generation workflow for both issue comments and review comments
- capture the pull request number for follow-up actions and grant issues permission for status messaging

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68f37ffe53cc832c87716663f9cd785a