### PR TITLE
Allow admin auth to accept case-insensitive bearer tokens

### DIFF
--- a/cmd/api/auth.go
+++ b/cmd/api/auth.go
@@ -106,11 +106,13 @@ func parseBearerToken(header string) (string, error) {
 	if header == "" {
 		return "", errors.New("missing authorization header")
 	}
-	const prefix = "Bearer "
-	if !strings.HasPrefix(header, prefix) {
+
+	parts := strings.Fields(header)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
 		return "", errors.New("authorization header is not a bearer token")
 	}
-	token := strings.TrimSpace(strings.TrimPrefix(header, prefix))
+
+	token := strings.TrimSpace(parts[1])
 	if token == "" {
 		return "", errors.New("authorization token missing")
 	}

--- a/cmd/api/auth_test.go
+++ b/cmd/api/auth_test.go
@@ -1,0 +1,39 @@
+package main
+
+import "testing"
+
+func TestParseBearerToken(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  string
+		want    string
+		wantErr bool
+	}{
+		{name: "standard", header: "Bearer token", want: "token"},
+		{name: "lowercase", header: "bearer token", want: "token"},
+		{name: "extra spaces", header: "  BEARER   token   ", want: "token"},
+		{name: "missing token", header: "Bearer", wantErr: true},
+		{name: "wrong scheme", header: "Basic token", wantErr: true},
+		{name: "empty", header: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseBearerToken(tt.header)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != tt.want {
+				t.Fatalf("expected %q got %q", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- accept bearer tokens regardless of the header scheme casing when parsing the Authorization header
- add unit tests covering lowercase, uppercase, and malformed bearer tokens

## Testing
- go test ./cmd/api -run TestParseBearerToken -count=1

------
https://chatgpt.com/codex/tasks/task_e_68f48ea6188c832ca3eedf8f0e1a2e40