### PR TITLE
Fix role queries to join companies with correct columns

### DIFF
--- a/internal/data/roles.go
+++ b/internal/data/roles.go
@@ -51,7 +51,7 @@ func (r RoleModel) Insert(role *Role) error {
 		"inserted_role.updatedAt as updatedAt",
 		"companies.name as company",
 		"companies.icon as companyIcon",
-	).From("inserted_role").LeftJoin("companies", "id", "companyId").QueryRow()
+        ).From("inserted_role").LeftJoin("companies", "companyId", "id").QueryRow()
 
 	if err != nil {
 		return err
@@ -71,7 +71,7 @@ func (r RoleModel) Get(roleId int64) (*Role, error) {
 			"roles.endDate AS endDate", "roles.title AS title", "roles.subtitle AS subtitle", "roles.slug AS slug",
 			"roles.description AS description", "roles.skills AS skills",
 			"companies.id as companyId", "companies.name as company", "companies.icon as companyIcon").
-		LeftJoin("companies", "id", "companyId").
+                LeftJoin("companies", "companyId", "id").
 		WhereEqual("roles.deletedAt", nil).
 		WhereEqual("roles.id", roleId).
 		QueryRow()


### PR DESCRIPTION
## Summary
- update the RoleModel Insert and Get joins so the left table provides the companyId column expected by the query builder

## Testing
- go test ./pkg/querybuilder -run TestSelectQueryBuilder_LeftJoin -v

------
https://chatgpt.com/codex/tasks/task_e_68f495883604832cbe76e917a681abc9