### PR TITLE
Generate slugs when creating or updating roles

### DIFF
--- a/cmd/api/handler_roles.go
+++ b/cmd/api/handler_roles.go
@@ -47,6 +47,8 @@ func (app *application) getCreateRolesHandler(w http.ResponseWriter, r *http.Req
 			Description: input.Description,
 			Skills:      input.Skills,
 		}
+		role.Slug = slugify(role.Title)
+		role.UpdatedAt = time.Now()
 		err = app.models.Roles.Insert(role)
 		if err != nil {
 			app.logger.Printf("Error: %s", err)
@@ -124,6 +126,7 @@ func (app *application) updateRole(w http.ResponseWriter, r *http.Request) {
 	}
 	if input.Title != nil {
 		role.Title = *input.Title
+		role.Slug = slugify(*input.Title)
 	}
 	if input.Subtitle != nil {
 		role.Subtitle = *input.Subtitle
@@ -137,6 +140,7 @@ func (app *application) updateRole(w http.ResponseWriter, r *http.Request) {
 	if len(input.Skills) > 0 {
 		role.Skills = input.Skills
 	}
+	role.UpdatedAt = time.Now()
 	err = app.models.Roles.Update(role)
 	if err != nil {
 		app.logger.Printf("Could not update role: %d. Error: %s", id, err)


### PR DESCRIPTION
## Summary
- slugify role titles before inserting or updating so database constraints are respected
- refresh role timestamps on create and update to avoid stale values

## Testing
- go test ./pkg/...

------
https://chatgpt.com/codex/tasks/task_e_68f4989709b8832cb89572e13ff41ca7