### PR TITLE
Ensure select queries send parameters when CTEs provide values

### DIFF
--- a/pkg/querybuilder/select.go
+++ b/pkg/querybuilder/select.go
@@ -92,7 +92,7 @@ func (q *SelectQueryBuilder) Query() (*sql.Rows, error) {
 		return nil, err
 	}
 	values := q.buildPreparedStatementValues()
-	if q.queryBuilder.preparedVariableOffset > 0 {
+	if len(values) > 0 {
 		return q.queryBuilder.DB.Query(*query, values...)
 	}
 	return q.queryBuilder.DB.Query(*query)
@@ -103,8 +103,8 @@ func (q *SelectQueryBuilder) QueryRow() (*sql.Row, error) {
 	if err != nil {
 		return nil, err
 	}
-	if q.queryBuilder.preparedVariableOffset > 0 {
-		values := q.buildPreparedStatementValues()
+	values := q.buildPreparedStatementValues()
+	if len(values) > 0 {
 		return q.queryBuilder.DB.QueryRow(*query, values...), nil
 	}
 	return q.queryBuilder.DB.QueryRow(*query), nil


### PR DESCRIPTION
## Summary
- update the select query builder to pass parameters whenever prepared values are present
- ensure QueryRow calls include values coming from common table expressions to avoid missing parameter errors

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f49b1d6380832c95fc0543f1e213e1