### PR TITLE
Support fetching public notes by slug

### DIFF
--- a/cmd/api/handler_public_test.go
+++ b/cmd/api/handler_public_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+	"log"
+	"os"
+
+	"api.etin.dev/internal/data"
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestGetPublicNotesForContentHandler(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("unexpected error creating sqlmock: %s", err)
+	}
+	defer db.Close()
+
+	logger := log.New(os.Stdout, "", 0)
+	models := data.NewModels(db, logger)
+
+	app := &application{
+		logger: logger,
+		models: models,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /public/v1/{contentType}/{idOrSlug}/notes", app.getPublicNotesForContentHandler)
+
+	t.Run("Valid Project Slug", func(t *testing.T) {
+		slug := "my-project"
+		projectID := int64(10)
+
+		// Expect GetBySlug for Project
+		// The query builder generates SELECT ... FROM projects WHERE deletedAt IS NULL AND slug = $1
+		mock.ExpectQuery(`SELECT id, createdAt, updatedAt, deletedAt, startDate, endDate, title, slug, description, imageUrl FROM projects WHERE deletedAt IS NULL AND slug = \$1`).
+			WithArgs(slug).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "createdAt", "updatedAt", "deletedAt", "startDate", "endDate", "title", "slug", "description", "imageUrl"}).
+				AddRow(projectID, time.Now(), time.Now(), nil, time.Now(), nil, "Title", slug, "Desc", "img.jpg"))
+
+		// Expect GetNotesForItem
+		mock.ExpectQuery(`SELECT notes.id, .* FROM item_notes .*`).
+			WithArgs("projects", projectID, sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "createdAt", "updatedAt", "deletedAt", "publishedAt", "title", "subtitle", "slug", "body"}))
+
+		req := httptest.NewRequest(http.MethodGet, "/public/v1/projects/"+slug+"/notes", nil)
+		rr := httptest.NewRecorder()
+
+		mux.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rr.Code)
+		}
+	})
+
+	t.Run("Valid Project ID", func(t *testing.T) {
+		projectID := int64(20)
+
+		// Expect Get for Project (Verification step)
+		mock.ExpectQuery(`SELECT id, createdAt, updatedAt, deletedAt, startDate, endDate, title, slug, description, imageUrl FROM projects WHERE deletedAt IS NULL AND id = \$1`).
+			WithArgs(projectID).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "createdAt", "updatedAt", "deletedAt", "startDate", "endDate", "title", "slug", "description", "imageUrl"}).
+				AddRow(projectID, time.Now(), time.Now(), nil, time.Now(), nil, "Title", "slug", "Desc", "img.jpg"))
+
+		// Expect GetNotesForItem
+		mock.ExpectQuery(`SELECT notes.id, .* FROM item_notes .*`).
+			WithArgs("projects", projectID, sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "createdAt", "updatedAt", "deletedAt", "publishedAt", "title", "subtitle", "slug", "body"}))
+
+		req := httptest.NewRequest(http.MethodGet, "/public/v1/projects/20/notes", nil)
+		rr := httptest.NewRecorder()
+
+		mux.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rr.Code)
+		}
+	})
+
+	t.Run("Invalid Slug", func(t *testing.T) {
+		slug := "invalid-slug"
+
+		// Expect GetBySlug for Project to fail
+		mock.ExpectQuery(`SELECT id, createdAt, updatedAt, deletedAt, startDate, endDate, title, slug, description, imageUrl FROM projects WHERE deletedAt IS NULL AND slug = \$1`).
+			WithArgs(slug).
+			WillReturnError(sql.ErrNoRows)
+
+		req := httptest.NewRequest(http.MethodGet, "/public/v1/projects/"+slug+"/notes", nil)
+		rr := httptest.NewRecorder()
+
+		mux.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", rr.Code)
+		}
+	})
+
+	t.Run("Invalid ID", func(t *testing.T) {
+		id := int64(999)
+
+		// Expect Get for Project to fail
+		mock.ExpectQuery(`SELECT id, createdAt, updatedAt, deletedAt, startDate, endDate, title, slug, description, imageUrl FROM projects WHERE deletedAt IS NULL AND id = \$1`).
+			WithArgs(id).
+			WillReturnError(sql.ErrNoRows)
+
+		req := httptest.NewRequest(http.MethodGet, "/public/v1/projects/999/notes", nil)
+		rr := httptest.NewRecorder()
+
+		mux.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", rr.Code)
+		}
+	})
+}

--- a/cmd/api/openapi.json
+++ b/cmd/api/openapi.json
@@ -1242,6 +1242,62 @@
         ]
       }
     },
+    "/public/v1/{contentType}/{idOrSlug}/notes": {
+      "get": {
+        "description": "Retrieve notes associated with a project, role, or another note, identified by ID or Slug.",
+        "operationId": "listPublicNotesForContent",
+        "parameters": [
+          {
+            "description": "Type of content to fetch notes for.",
+            "in": "path",
+            "name": "contentType",
+            "required": true,
+            "schema": {
+              "enum": [
+                "projects",
+                "roles",
+                "notes"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Numeric ID or URL-friendly Slug of the item.",
+            "in": "path",
+            "name": "idOrSlug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicNotesResponse"
+                }
+              }
+            },
+            "description": "Public notes retrieved."
+          },
+          "400": {
+            "description": "Invalid content type or identifier."
+          },
+          "404": {
+            "description": "Item not found."
+          },
+          "500": {
+            "description": "Server error retrieving notes."
+          }
+        },
+        "summary": "List public notes for a specific item",
+        "tags": [
+          "Public Content"
+        ]
+      }
+    },
     "/swagger": {
       "get": {
         "operationId": "getSwaggerDocument",

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -7,7 +7,7 @@ func (app *application) routes() http.Handler {
 
 	mux.HandleFunc("GET /swagger", app.swaggerHandler)
 	mux.HandleFunc("GET /public/v1/notes", app.getPublicNotesHandler)
-	mux.HandleFunc("GET /public/v1/{contentType}/{id}/notes", app.getPublicNotesForContentHandler)
+	mux.HandleFunc("GET /public/v1/{contentType}/{idOrSlug}/notes", app.getPublicNotesForContentHandler)
 	mux.HandleFunc("GET /public/v1/projects/notes", app.getPublicAllNotesForContentHandler)
 	mux.HandleFunc("GET /public/v1/roles/notes", app.getPublicAllNotesForContentHandler)
 	mux.HandleFunc("GET /public/v1/notes/notes", app.getPublicAllNotesForContentHandler)

--- a/pkg/openapi/spec.go
+++ b/pkg/openapi/spec.go
@@ -723,6 +723,41 @@ func buildPaths() map[string]any {
 				},
 			},
 		},
+		"/public/v1/{contentType}/{idOrSlug}/notes": map[string]any{
+			"get": map[string]any{
+				"operationId": "listPublicNotesForContent",
+				"summary":     "List public notes for a specific item",
+				"description": "Retrieve notes associated with a project, role, or another note, identified by ID or Slug.",
+				"tags":        []string{"Public Content"},
+				"parameters": []map[string]any{
+					{
+						"name":        "contentType",
+						"in":          "path",
+						"required":    true,
+						"description": "Type of content to fetch notes for.",
+						"schema": map[string]any{
+							"type": "string",
+							"enum": []string{"projects", "roles", "notes"},
+						},
+					},
+					{
+						"name":        "idOrSlug",
+						"in":          "path",
+						"required":    true,
+						"description": "Numeric ID or URL-friendly Slug of the item.",
+						"schema": map[string]any{
+							"type": "string",
+						},
+					},
+				},
+				"responses": map[string]any{
+					"200": jsonResponse("Public notes retrieved.", "PublicNotesResponse"),
+					"400": noContent("Invalid content type or identifier."),
+					"404": noContent("Item not found."),
+					"500": noContent("Server error retrieving notes."),
+				},
+			},
+		},
 		"/v1/admin/login": map[string]any{
 			"post": map[string]any{
 				"operationId": "adminLogin",


### PR DESCRIPTION
This PR updates the public API endpoint for fetching notes related to a content type (Projects, Roles, Notes) to support lookup by Slug in addition to ID.

The endpoint `GET /public/v1/{contentType}/{id}/notes` is now `GET /public/v1/{contentType}/{idOrSlug}/notes`.

If an integer is provided, it is treated as an ID (with existence verification for known types).
If a string is provided, it is treated as a Slug and resolved to an ID using `GetBySlug` methods for the respective models.
Returns 404 if the item is not found by ID or Slug.
Returns 400 for unknown content types when using Slug lookup.

---
*PR created automatically by Jules for task [15143980040888632323](https://jules.google.com/task/15143980040888632323) started by @obasekietinosa*