### PR TITLE
Add Related Notes to Public Note Endpoint

### DIFF
--- a/cmd/api/handler_public_items.go
+++ b/cmd/api/handler_public_items.go
@@ -63,7 +63,7 @@ func (app *application) getPublicProjectHandler(w http.ResponseWriter, r *http.R
 			return
 		}
 		relatedItems := relatedItemsMap[note.ID]
-		publicNotes = append(publicNotes, buildPublicNote(note, noteTags, relatedItems))
+		publicNotes = append(publicNotes, buildPublicNote(note, noteTags, relatedItems, nil))
 	}
 
 	app.writeJSON(w, http.StatusOK, envelope{"project": buildPublicProject(project, tags, publicNotes)})
@@ -112,7 +112,14 @@ func (app *application) getPublicNoteHandler(w http.ResponseWriter, r *http.Requ
 	}
 	relatedItems := relatedItemsMap[note.ID]
 
-	app.writeJSON(w, http.StatusOK, envelope{"note": buildPublicNote(note, tags, relatedItems)})
+	relatedNotes, err := app.getRelatedNotes(r, note, tags)
+	if err != nil {
+		app.logger.Printf("Error retrieving related notes: %s", err)
+		// We can still proceed without related notes
+		relatedNotes = []publicNote{}
+	}
+
+	app.writeJSON(w, http.StatusOK, envelope{"note": buildPublicNote(note, tags, relatedItems, relatedNotes)})
 }
 
 func (app *application) getPublicRoleHandler(w http.ResponseWriter, r *http.Request) {
@@ -161,7 +168,7 @@ func (app *application) getPublicRoleHandler(w http.ResponseWriter, r *http.Requ
 			return
 		}
 		relatedItems := relatedItemsMap[note.ID]
-		publicNotes = append(publicNotes, buildPublicNote(note, noteTags, relatedItems))
+		publicNotes = append(publicNotes, buildPublicNote(note, noteTags, relatedItems, nil))
 	}
 
 	app.writeJSON(w, http.StatusOK, envelope{"role": buildPublicRole(role, publicNotes)})

--- a/cmd/api/openapi.json
+++ b/cmd/api/openapi.json
@@ -586,6 +586,12 @@
             },
             "type": "array"
           },
+          "relatedNotes": {
+            "items": {
+              "$ref": "#/components/schemas/PublicNote"
+            },
+            "type": "array"
+          },
           "tags": {
             "items": {
               "$ref": "#/components/schemas/PublicTag"

--- a/internal/data/notes.go
+++ b/internal/data/notes.go
@@ -373,6 +373,122 @@ func (n NoteModel) GetAllPublished() ([]*Note, error) {
 	return notes, nil
 }
 
+func (n NoteModel) GetPreviousPublished(publishedAt time.Time) (*Note, error) {
+	row, err := n.Query.SetBaseTable("notes").Select(
+		"id",
+		"createdAt",
+		"updatedAt",
+		"deletedAt",
+		"publishedAt",
+		"title",
+		"subtitle",
+		"slug",
+		"body",
+	).WhereEqual("deletedAt", nil).
+		WhereLessThan("publishedAt", publishedAt).
+		OrderBy("publishedAt", "desc").
+		Limit(1).
+		QueryRow()
+	if err != nil {
+		return nil, err
+	}
+
+	var note Note
+	var deletedAt sql.NullTime
+	var publishedAtVal sql.NullTime
+	var slugVal sql.NullString
+
+	err = row.Scan(
+		&note.ID,
+		&note.CreatedAt,
+		&note.UpdatedAt,
+		&deletedAt,
+		&publishedAtVal,
+		&note.Title,
+		&note.Subtitle,
+		&slugVal,
+		&note.Body,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.New("record not found")
+		}
+		return nil, err
+	}
+
+	if deletedAt.Valid {
+		note.DeletedAt = &deletedAt.Time
+	}
+
+	if publishedAtVal.Valid {
+		note.PublishedAt = &publishedAtVal.Time
+	}
+
+	if slugVal.Valid {
+		note.Slug = slugVal.String
+	}
+
+	return &note, nil
+}
+
+func (n NoteModel) GetNextPublished(publishedAt time.Time) (*Note, error) {
+	row, err := n.Query.SetBaseTable("notes").Select(
+		"id",
+		"createdAt",
+		"updatedAt",
+		"deletedAt",
+		"publishedAt",
+		"title",
+		"subtitle",
+		"slug",
+		"body",
+	).WhereEqual("deletedAt", nil).
+		WhereGreaterThan("publishedAt", publishedAt).
+		OrderBy("publishedAt", "asc").
+		Limit(1).
+		QueryRow()
+	if err != nil {
+		return nil, err
+	}
+
+	var note Note
+	var deletedAt sql.NullTime
+	var publishedAtVal sql.NullTime
+	var slugVal sql.NullString
+
+	err = row.Scan(
+		&note.ID,
+		&note.CreatedAt,
+		&note.UpdatedAt,
+		&deletedAt,
+		&publishedAtVal,
+		&note.Title,
+		&note.Subtitle,
+		&slugVal,
+		&note.Body,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.New("record not found")
+		}
+		return nil, err
+	}
+
+	if deletedAt.Valid {
+		note.DeletedAt = &deletedAt.Time
+	}
+
+	if publishedAtVal.Valid {
+		note.PublishedAt = &publishedAtVal.Time
+	}
+
+	if slugVal.Valid {
+		note.Slug = slugVal.String
+	}
+
+	return &note, nil
+}
+
 func (n NoteModel) GetBySlug(slug string) (*Note, error) {
 	row, err := n.Query.SetBaseTable("notes").Select(
 		"id",

--- a/pkg/openapi/spec.go
+++ b/pkg/openapi/spec.go
@@ -332,6 +332,10 @@ func buildSchemas() map[string]any {
 					"type":  "array",
 					"items": ref("PublicRelatedItem"),
 				},
+				"relatedNotes": map[string]any{
+					"type":  "array",
+					"items": ref("PublicNote"),
+				},
 			},
 		},
 		"PublicProject": map[string]any{


### PR DESCRIPTION
Implemented logic to fetch and display related notes for a given public note. Related notes are sourced from shared projects/roles, shared tags, and chronological proximity, limited to 5 items. Updated data models and handlers accordingly.

---
*PR created automatically by Jules for task [6816623443746129008](https://jules.google.com/task/6816623443746129008) started by @obasekietinosa*